### PR TITLE
Доработки OBS: автообновление и доводка оверлея

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
           --output .\publish\framework-dependent
           -p:PublishSingleFile=true
           -p:PublishReadyToRun=true
+          -p:UpdatableBuild=true
           -p:Version=${{ needs.prepare.outputs.version }}
           --no-self-contained
 
@@ -98,6 +99,7 @@ jobs:
           -p:PublishReadyToRun=true
           -p:IncludeNativeLibrariesForSelfExtract=true
           -p:PortableMode=true
+          -p:UpdatableBuild=true
           -p:Version=${{ needs.prepare.outputs.version }}
           --self-contained
 
@@ -113,6 +115,12 @@ jobs:
           Move-Item -Path ".\publish\portable\PoproshaykaBot-v$version-$arch-portable.exe" -Destination ".\artifacts\"
           Compress-Archive -Path ".\artifacts\PoproshaykaBot-v$version-$arch.exe" -DestinationPath ".\artifacts\PoproshaykaBot-v$version-$arch.zip"
           Compress-Archive -Path ".\artifacts\PoproshaykaBot-v$version-$arch-portable.exe" -DestinationPath ".\artifacts\PoproshaykaBot-v$version-$arch-portable.zip"
+          Get-ChildItem ".\artifacts\*.exe" | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash  $($_.Name)"
+          } | Set-Content ".\artifacts\SHA256SUMS-$arch.txt" -Encoding ascii
+          $tfm = (Select-String -Path ".\PoproshaykaBot.WinForms.csproj" -Pattern '<TargetFramework>(.*?)</TargetFramework>').Matches[0].Groups[1].Value
+          Set-Content ".\artifacts\RUNTIME-$arch.txt" -Value $tfm -Encoding ascii -NoNewline
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.1.0.6</Version>
+    <Version>3.1.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.1.0.9</Version>
+    <Version>3.1.0.10</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.1.0.10</Version>
+    <Version>3.1.0.11</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.1.0.8</Version>
+    <Version>3.1.0.9</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>3.1.0.7</Version>
+    <Version>3.1.0.8</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzers">

--- a/PoproshaykaBot.Core.Tests/Broadcast/StreamSessionStatisticsHandlerTests.cs
+++ b/PoproshaykaBot.Core.Tests/Broadcast/StreamSessionStatisticsHandlerTests.cs
@@ -81,10 +81,10 @@ public sealed class StreamSessionStatisticsHandlerTests
         });
     }
 
-    private static ChatMessageReceived Chat(string userId, string displayName)
+    private static ChatMessageReceived Chat(string userId, string displayName, bool isBot = false)
     {
         return new(Channel, Guid.NewGuid().ToString("N"), userId, displayName.ToLowerInvariant(), displayName,
-            "сообщение", UserStatus.None, false, new());
+            "сообщение", UserStatus.None, false, new(), isBot);
     }
 
     [Test]
@@ -161,5 +161,28 @@ public sealed class StreamSessionStatisticsHandlerTests
         await _handler.HandleAsync(new StreamWentOffline(Channel), CancellationToken.None);
 
         Assert.That(_captured, Is.Null);
+    }
+
+    [Test]
+    public async Task ChatMessageReceived_FromBot_DoesNotCountTowardSession()
+    {
+        await _handler.HandleAsync(Online(), CancellationToken.None);
+
+        await _handler.HandleAsync(Chat("u1", "Alice"), CancellationToken.None);
+        await _handler.HandleAsync(Chat("bot", "MyBot", true), CancellationToken.None);
+        await _handler.HandleAsync(Chat("bot", "MyBot", true), CancellationToken.None);
+
+        _timeProvider.UtcNow = StreamStart.AddHours(1);
+
+        await _handler.HandleAsync(new StreamWentOffline(Channel), CancellationToken.None);
+
+        Assert.That(_captured, Is.Not.Null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_captured!.MessageCount, Is.EqualTo(1));
+            Assert.That(_captured.ChatterCount, Is.EqualTo(1));
+            Assert.That(_captured.Chatters.Select(c => c.DisplayName), Is.EqualTo(new[] { "Alice" }));
+        }
     }
 }

--- a/PoproshaykaBot.Core.Tests/Chat/Handlers/FarewellMessageHandlerTests.cs
+++ b/PoproshaykaBot.Core.Tests/Chat/Handlers/FarewellMessageHandlerTests.cs
@@ -1,0 +1,142 @@
+﻿using PoproshaykaBot.Core.Chat;
+using PoproshaykaBot.Core.Chat.Handlers;
+using PoproshaykaBot.Core.Infrastructure;
+using PoproshaykaBot.Core.Infrastructure.Events;
+using PoproshaykaBot.Core.Infrastructure.Events.Lifecycle;
+using PoproshaykaBot.Core.Settings;
+
+namespace PoproshaykaBot.Core.Tests.Chat.Handlers;
+
+[TestFixture]
+public sealed class FarewellMessageHandlerTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        _channelProvider = Substitute.For<IChannelProvider>();
+        _channelProvider.Channel.Returns("qp_illson");
+
+        _settingsManager = Substitute.For<SettingsManager>(NullLogger<SettingsManager>.Instance);
+        _settings = new();
+        _settingsManager.Current.Returns(_settings);
+
+        _audienceTracker = new(_settingsManager);
+
+        _messenger = Substitute.For<IChatMessenger>();
+        _eventBus = Substitute.For<IEventBus>();
+        _eventBus.Subscribe(Arg.Any<IEventHandler<BotLifecyclePhaseChanged>>()).Returns(Substitute.For<IDisposable>());
+
+        _handler = new(_channelProvider,
+            _audienceTracker,
+            _messenger,
+            _settingsManager,
+            _eventBus,
+            NullLogger<FarewellMessageHandler>.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _handler.Dispose();
+    }
+
+    private IChannelProvider _channelProvider = null!;
+    private SettingsManager _settingsManager = null!;
+    private AudienceTracker _audienceTracker = null!;
+    private IChatMessenger _messenger = null!;
+    private IEventBus _eventBus = null!;
+    private AppSettings _settings = null!;
+    private FarewellMessageHandler _handler = null!;
+
+    [Test]
+    public async Task DoesNothingForNonDisconnectingPhase()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = true;
+        _settings.Twitch.Messages.DisconnectionEnabled = true;
+        _audienceTracker.OnUserMessage("u1", "Alice");
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Connected), CancellationToken.None);
+        await _handler.HandleAsync(new(BotLifecyclePhase.Connecting), CancellationToken.None);
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnected), CancellationToken.None);
+
+        _messenger.DidNotReceive().Send(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SkipsAllMessagesWhenChannelIsUnknown()
+    {
+        _channelProvider.Channel.Returns((string?)null);
+        _settings.Twitch.Messages.FarewellEnabled = true;
+        _settings.Twitch.Messages.DisconnectionEnabled = true;
+        _audienceTracker.OnUserMessage("u1", "Alice");
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.DidNotReceive().Send(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SendsCollectiveFarewellAndDisconnectionJoined()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = true;
+        _settings.Twitch.Messages.Farewell = "До свидания, {username}!";
+        _settings.Twitch.Messages.DisconnectionEnabled = true;
+        _settings.Twitch.Messages.Disconnection = "Пока-пока!";
+        _audienceTracker.OnUserMessage("u1", "Alice");
+        _audienceTracker.OnUserMessage("u2", "Bob");
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.Received(1).Send("До свидания, Alice, Bob! Пока-пока!");
+    }
+
+    [Test]
+    public async Task SendsOnlyDisconnectionWhenFarewellIsDisabled()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = false;
+        _settings.Twitch.Messages.DisconnectionEnabled = true;
+        _settings.Twitch.Messages.Disconnection = "Пока-пока!";
+        _audienceTracker.OnUserMessage("u1", "Alice");
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.Received(1).Send("Пока-пока!");
+    }
+
+    [Test]
+    public async Task SendsOnlyDisconnectionWhenAudienceTrackerIsEmpty()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = true;
+        _settings.Twitch.Messages.Farewell = "До свидания, {username}!";
+        _settings.Twitch.Messages.DisconnectionEnabled = true;
+        _settings.Twitch.Messages.Disconnection = "Пока-пока!";
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.Received(1).Send("Пока-пока!");
+    }
+
+    [Test]
+    public async Task SendsOnlyCollectiveFarewellWhenDisconnectionDisabled()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = true;
+        _settings.Twitch.Messages.Farewell = "Спасибо, {username}!";
+        _settings.Twitch.Messages.DisconnectionEnabled = false;
+        _audienceTracker.OnUserMessage("u1", "Alice");
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.Received(1).Send("Спасибо, Alice!");
+    }
+
+    [Test]
+    public async Task SendsNothingWhenBothMessagesAreDisabledAndTrackerEmpty()
+    {
+        _settings.Twitch.Messages.FarewellEnabled = false;
+        _settings.Twitch.Messages.DisconnectionEnabled = false;
+
+        await _handler.HandleAsync(new(BotLifecyclePhase.Disconnecting), CancellationToken.None);
+
+        _messenger.DidNotReceive().Send(Arg.Any<string>());
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
+++ b/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
@@ -289,6 +289,93 @@ public sealed class ObsIntegrationServiceTests
     }
 
     [Test]
+    public async Task RefreshConfiguredChatSourcesAsyncSendsRefreshForEachConfiguredSourceAsync()
+    {
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");
+
+        var refreshed = await _service.RefreshConfiguredChatSourcesAsync(new()
+        {
+            Enabled = true,
+            ChatRefreshSources = ["Chat Overlay", "Secondary Chat"],
+        }, CancellationToken.None);
+
+        Assert.That(refreshed, Is.EqualTo(2));
+
+        var refreshRequests = _client.Requests
+            .Where(request => string.Equals(request.RequestType, "PressInputPropertiesButton", StringComparison.Ordinal))
+            .Select(request => request.RequestData!.Value.GetProperty("inputName").GetString())
+            .ToArray();
+
+        Assert.That(refreshRequests, Is.EqualTo(["Chat Overlay", "Secondary Chat"]));
+
+        var firstButton = _client.Requests
+            .First(request => string.Equals(request.RequestType, "PressInputPropertiesButton", StringComparison.Ordinal))
+            .RequestData!.Value.GetProperty("propertyName")
+            .GetString();
+
+        Assert.That(firstButton, Is.EqualTo("refreshnocache"));
+    }
+
+    [Test]
+    public async Task RefreshConfiguredChatSourcesAsyncFallsBackToSourceNameWhenListEmptyAsync()
+    {
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");
+
+        var refreshed = await _service.RefreshConfiguredChatSourcesAsync(new()
+        {
+            Enabled = true,
+            SourceName = "PoproshaykaBot Chat",
+        }, CancellationToken.None);
+
+        Assert.That(refreshed, Is.EqualTo(1));
+
+        var refreshRequest = _client.Requests.Single(request =>
+            string.Equals(request.RequestType, "PressInputPropertiesButton", StringComparison.Ordinal));
+
+        Assert.That(refreshRequest.RequestData!.Value.GetProperty("inputName").GetString(),
+            Is.EqualTo("PoproshaykaBot Chat"));
+    }
+
+    [Test]
+    public async Task RefreshConfiguredChatSourcesAsyncReturnsZeroWhenNoSourcesAndNoFallbackAsync()
+    {
+        var refreshed = await _service.RefreshConfiguredChatSourcesAsync(new()
+        {
+            Enabled = true,
+            SourceName = string.Empty,
+        }, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(refreshed, Is.Zero);
+            Assert.That(_client.ConnectCount, Is.Zero);
+            Assert.That(_client.Requests, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task ListBrowserSourceNamesAsyncReturnsOnlyBrowserSourceInputsAsync()
+    {
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");
+        _client.EnqueueResponse("GetInputList", """
+                                                {
+                                                  "inputs": [
+                                                    {"inputName": "Mic/Aux", "inputKind": "wasapi_input_capture", "unversionedInputKind": "wasapi_input_capture"},
+                                                    {"inputName": "Chat Overlay", "inputKind": "browser_source", "unversionedInputKind": "browser_source"},
+                                                    {"inputName": "Donations", "inputKind": "browser_source_v2", "unversionedInputKind": "browser_source"}
+                                                  ]
+                                                }
+                                                """);
+
+        var names = await _service.ListBrowserSourceNamesAsync(new()
+        {
+            Enabled = true,
+        }, CancellationToken.None);
+
+        Assert.That(names, Is.EqualTo(["Chat Overlay", "Donations"]));
+    }
+
+    [Test]
     public async Task ListInputNamesAsyncReturnsInputNamesFromObsAsync()
     {
         _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");

--- a/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
+++ b/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
@@ -135,10 +135,10 @@ public sealed class ObsIntegrationServiceTests
             Assert.That(snapshot.CurrentSceneName, Is.EqualTo("Main"));
             Assert.That(snapshot.IsStreaming, Is.True);
             Assert.That(snapshot.IsRecording, Is.False);
-            Assert.That(snapshot.Microphone, Is.Not.Null);
-            Assert.That(snapshot.Microphone!.Name, Is.EqualTo("Mic/Aux"));
-            Assert.That(snapshot.Microphone.IsMuted, Is.True);
-            Assert.That(snapshot.Microphone.VolumeDecibels, Is.EqualTo(-12.5).Within(0.01));
+            Assert.That(snapshot.AudioSources, Has.Count.EqualTo(1));
+            Assert.That(snapshot.AudioSources[0].Name, Is.EqualTo("Mic/Aux"));
+            Assert.That(snapshot.AudioSources[0].IsMuted, Is.True);
+            Assert.That(snapshot.AudioSources[0].VolumeDecibels, Is.EqualTo(-12.5).Within(0.01));
         }
 
         var muteRequest = _client.Requests.Single(r =>
@@ -182,16 +182,70 @@ public sealed class ObsIntegrationServiceTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(snapshot.Microphone, Is.Not.Null);
-            Assert.That(snapshot.Microphone!.Name, Is.EqualTo("Line In"));
-            Assert.That(snapshot.Microphone.IsMuted, Is.False);
-            Assert.That(snapshot.Microphone.VolumeDecibels, Is.EqualTo(-6.0).Within(0.01));
+            Assert.That(snapshot.AudioSources, Has.Count.EqualTo(1));
+            Assert.That(snapshot.AudioSources[0].Name, Is.EqualTo("Line In"));
+            Assert.That(snapshot.AudioSources[0].IsMuted, Is.False);
+            Assert.That(snapshot.AudioSources[0].VolumeDecibels, Is.EqualTo(-6.0).Within(0.01));
         }
 
         var muteRequest = _client.Requests.Single(r =>
             string.Equals(r.RequestType, "GetInputMute", StringComparison.Ordinal));
 
         Assert.That(muteRequest.RequestData!.Value.GetProperty("inputName").GetString(), Is.EqualTo("Line In"));
+    }
+
+    [Test]
+    public async Task GetDashboardSnapshotAsyncReturnsAllConfiguredAudioSourcesInOrderAsync()
+    {
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");
+        _client.EnqueueResponse("GetCurrentProgramScene", """{"currentProgramSceneName":"Main"}""");
+        _client.EnqueueResponse("GetStreamStatus", """{"outputActive":false}""");
+        _client.EnqueueResponse("GetRecordStatus", """{"outputActive":false}""");
+        _client.EnqueueResponse("GetInputList", """
+                                                {
+                                                  "inputs": [
+                                                    {
+                                                      "inputName": "Mic/Aux",
+                                                      "inputKind": "wasapi_input_capture",
+                                                      "unversionedInputKind": "wasapi_input_capture"
+                                                    },
+                                                    {
+                                                      "inputName": "Desktop Audio",
+                                                      "inputKind": "wasapi_output_capture",
+                                                      "unversionedInputKind": "wasapi_output_capture"
+                                                    }
+                                                  ]
+                                                }
+                                                """);
+
+        _client.EnqueueResponse("GetInputMute", """{"inputMuted":false}""");
+        _client.EnqueueResponse("GetInputVolume", """{"inputVolumeDb":-3.0,"inputVolumeMul":0.8}""");
+        _client.EnqueueResponse("GetInputMute", """{"inputMuted":true}""");
+        _client.EnqueueResponse("GetInputVolume", """{"inputVolumeDb":-18.0,"inputVolumeMul":0.1}""");
+
+        var snapshot = await _service.GetDashboardSnapshotAsync(new()
+        {
+            Enabled = true,
+            DashboardSourceNames = ["Desktop Audio", "Mic/Aux"],
+        }, true, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.AudioSources, Has.Count.EqualTo(2));
+            Assert.That(snapshot.AudioSources[0].Name, Is.EqualTo("Desktop Audio"));
+            Assert.That(snapshot.AudioSources[0].IsMuted, Is.False);
+            Assert.That(snapshot.AudioSources[0].VolumeDecibels, Is.EqualTo(-3.0).Within(0.01));
+            Assert.That(snapshot.AudioSources[1].Name, Is.EqualTo("Mic/Aux"));
+            Assert.That(snapshot.AudioSources[1].IsMuted, Is.True);
+            Assert.That(snapshot.AudioSources[1].VolumeDecibels, Is.EqualTo(-18.0).Within(0.01));
+        }
+
+        var muteInputNames = _client.Requests
+            .Where(request => string.Equals(request.RequestType, "GetInputMute", StringComparison.Ordinal))
+            .Select(request => request.RequestData!.Value.GetProperty("inputName").GetString())
+            .ToArray();
+
+        Assert.That(muteInputNames, Is.EqualTo(new[] { "Desktop Audio", "Mic/Aux" }));
     }
 
     [Test]

--- a/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
+++ b/PoproshaykaBot.Core.Tests/Obs/ObsIntegrationServiceTests.cs
@@ -148,6 +148,30 @@ public sealed class ObsIntegrationServiceTests
     }
 
     [Test]
+    public async Task GetDashboardSnapshotAsyncReportsStreamAndPausedRecordingTimecodesAsync()
+    {
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");
+        _client.EnqueueResponse("GetCurrentProgramScene", """{"currentProgramSceneName":"Main"}""");
+        _client.EnqueueResponse("GetStreamStatus", """{"outputActive":true,"outputTimecode":"01:23:45.000"}""");
+        _client.EnqueueResponse("GetRecordStatus", """{"outputActive":true,"outputPaused":true,"outputTimecode":"00:12:34.500"}""");
+        _client.EnqueueResponse("GetInputList", """{"inputs":[]}""");
+
+        var snapshot = await _service.GetDashboardSnapshotAsync(new()
+        {
+            Enabled = true,
+        }, true, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.IsStreaming, Is.True);
+            Assert.That(snapshot.StreamTimecode, Is.EqualTo("01:23:45.000"));
+            Assert.That(snapshot.IsRecording, Is.True);
+            Assert.That(snapshot.IsRecordingPaused, Is.True);
+            Assert.That(snapshot.RecordTimecode, Is.EqualTo("00:12:34.500"));
+        }
+    }
+
+    [Test]
     public async Task GetDashboardSnapshotAsyncUsesConfiguredMicrophoneInputNameAsync()
     {
         _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0","obsWebSocketVersion":"5.5.2"}""");

--- a/PoproshaykaBot.Core.Tests/Obs/ObsStreamStartChatRefresherTests.cs
+++ b/PoproshaykaBot.Core.Tests/Obs/ObsStreamStartChatRefresherTests.cs
@@ -1,0 +1,244 @@
+﻿using PoproshaykaBot.Core.Infrastructure.Events;
+using PoproshaykaBot.Core.Obs;
+using PoproshaykaBot.Core.Settings;
+using PoproshaykaBot.Core.Settings.Stores;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Tests.Obs;
+
+[TestFixture]
+public sealed class ObsStreamStartChatRefresherTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        _tempFile = Path.Combine(Path.GetTempPath(), $"obs-integration-refresher-{Guid.NewGuid():N}.json");
+        _eventBus = new(NullLogger<InMemoryEventBus>.Instance);
+        _store = new(_eventBus, null, _tempFile);
+
+        _client = new();
+        _settingsManager = Substitute.For<SettingsManager>(NullLogger<SettingsManager>.Instance);
+        _settingsManager.Current.Returns(new AppSettings
+        {
+            Twitch =
+            {
+                HttpServerPort = 8099,
+            },
+        });
+
+        _integration = new(_client, _settingsManager, NullLogger<ObsIntegrationService>.Instance);
+        _refresher = new(_client, _store, _integration, NullLogger<ObsStreamStartChatRefresher>.Instance);
+    }
+
+    [TearDown]
+    public async Task TearDownAsync()
+    {
+        _integration.Dispose();
+        await _client.DisposeAsync();
+        if (File.Exists(_tempFile))
+        {
+            File.Delete(_tempFile);
+        }
+    }
+
+    private string _tempFile = null!;
+    private InMemoryEventBus _eventBus = null!;
+    private ObsIntegrationStore _store = null!;
+    private FakeObsWebSocketClient _client = null!;
+    private SettingsManager _settingsManager = null!;
+    private ObsIntegrationService _integration = null!;
+    private ObsStreamStartChatRefresher _refresher = null!;
+
+    [Test]
+    public async Task DoesNotRefreshWhenSettingDisabledAsync()
+    {
+        SaveSettings(true, false, "Chat Overlay");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: true);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Is.Empty);
+    }
+
+    [Test]
+    public async Task DoesNotRefreshWhenIntegrationDisabledAsync()
+    {
+        SaveSettings(false, true, "Chat Overlay");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: true);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Is.Empty);
+    }
+
+    [Test]
+    public async Task RefreshesEachConfiguredSourceOnStreamStartedAsync()
+    {
+        SaveSettings(true, true, "Chat Overlay", "Secondary Chat");
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0"}""");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: true);
+        await WaitForRefreshAsync(expectedRequests: 2);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Is.EqualTo(new[] { "Chat Overlay", "Secondary Chat" }));
+    }
+
+    [Test]
+    public async Task DoesNotRefreshOnRepeatedActiveEventsAsync()
+    {
+        SaveSettings(true, true, "Chat Overlay");
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0"}""");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: true);
+        await WaitForRefreshAsync(expectedRequests: 1);
+        _client.RaiseStreamStateChanged(active: true);
+        _client.RaiseStreamStateChanged(active: true);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RefreshesAgainAfterStreamStoppedAndStartedAsync()
+    {
+        SaveSettings(true, true, "Chat Overlay");
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0"}""");
+        _client.EnqueueResponse("GetVersion", """{"obsVersion":"31.0.0"}""");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: true);
+        await WaitForRefreshAsync(expectedRequests: 1);
+        _client.RaiseStreamStateChanged(active: false);
+        _client.RaiseStreamStateChanged(active: true);
+        await WaitForRefreshAsync(expectedRequests: 2);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task DoesNotRefreshOnStopEventAsync()
+    {
+        SaveSettings(true, true, "Chat Overlay");
+        _client.MarkConnected();
+
+        await _refresher.StartAsync(CancellationToken.None);
+        _client.RaiseStreamStateChanged(active: false);
+        await _refresher.StopAsync(CancellationToken.None);
+
+        Assert.That(_client.PressButtonRequests, Is.Empty);
+    }
+
+    private void SaveSettings(bool enabled, bool autoRefresh, params string[] sources)
+    {
+        _store.Save(new()
+        {
+            Enabled = enabled,
+            RefreshChatSourcesOnStreamStart = autoRefresh,
+            ChatRefreshSources = [.. sources],
+        });
+    }
+
+    private async Task WaitForRefreshAsync(int expectedRequests)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (_client.PressButtonRequests.Count < expectedRequests && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+    }
+
+    private sealed class FakeObsWebSocketClient : IObsWebSocketClient
+    {
+        private readonly Dictionary<string, Queue<JsonElement?>> _responses = new(StringComparer.Ordinal);
+        private readonly List<string> _pressButtonRequests = [];
+        private readonly object _lock = new();
+
+        public event EventHandler<ObsWebSocketEventArgs>? EventReceived;
+
+        public bool IsConnected { get; private set; }
+
+        public IReadOnlyList<string> PressButtonRequests
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return [.. _pressButtonRequests];
+                }
+            }
+        }
+
+        public void MarkConnected()
+        {
+            IsConnected = true;
+        }
+
+        public void RaiseStreamStateChanged(bool active)
+        {
+            var json = JsonSerializer.SerializeToElement(new { outputActive = active });
+            EventReceived?.Invoke(this, new("StreamStateChanged", 0, json));
+        }
+
+        public void EnqueueResponse(string requestType, string json)
+        {
+            if (!_responses.TryGetValue(requestType, out var queue))
+            {
+                queue = new();
+                _responses[requestType] = queue;
+            }
+
+            using var document = JsonDocument.Parse(json);
+            queue.Enqueue(document.RootElement.Clone());
+        }
+
+        public Task<ObsConnectionSnapshot> ConnectAsync(ObsConnectionOptions options, CancellationToken cancellationToken)
+        {
+            IsConnected = true;
+            return Task.FromResult(new ObsConnectionSnapshot(true, "31.0.0", "5.5.2", null));
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken)
+        {
+            IsConnected = false;
+            return Task.CompletedTask;
+        }
+
+        public Task<JsonElement?> SendRequestAsync(string requestType, object? requestData, CancellationToken cancellationToken)
+        {
+            if (string.Equals(requestType, "PressInputPropertiesButton", StringComparison.Ordinal) && requestData is not null)
+            {
+                var data = JsonSerializer.SerializeToElement(requestData);
+                if (data.TryGetProperty("inputName", out var inputName) && inputName.ValueKind == JsonValueKind.String)
+                {
+                    lock (_lock)
+                    {
+                        _pressButtonRequests.Add(inputName.GetString()!);
+                    }
+                }
+            }
+
+            if (_responses.TryGetValue(requestType, out var queue) && queue.Count > 0)
+            {
+                return Task.FromResult(queue.Dequeue());
+            }
+
+            return Task.FromResult<JsonElement?>(null);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Server/Endpoints/AvatarEndpointTests.cs
+++ b/PoproshaykaBot.Core.Tests/Server/Endpoints/AvatarEndpointTests.cs
@@ -15,7 +15,7 @@ public sealed class AvatarEndpointTests
                 services.AddRouting();
                 services.AddSingleton(new UserProfileImageProvider(rootProvider, NullLogger<UserProfileImageProvider>.Instance));
             },
-            sp => new AvatarEndpoint(sp.GetRequiredService<UserProfileImageProvider>()));
+            sp => new AvatarEndpoint(sp.GetRequiredService<UserProfileImageProvider>(), sp));
     }
 
     [Test]

--- a/PoproshaykaBot.Core.Tests/Server/Endpoints/ChatSettingsEndpointTests.cs
+++ b/PoproshaykaBot.Core.Tests/Server/Endpoints/ChatSettingsEndpointTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using PoproshaykaBot.Core.Infrastructure.Events;
+using PoproshaykaBot.Core.Infrastructure.Events.Settings;
 using PoproshaykaBot.Core.Server.Endpoints;
 using PoproshaykaBot.Core.Settings.Obs;
 using PoproshaykaBot.Core.Settings.Stores;
 using System.Net;
+using System.Text;
 using System.Text.Json;
 
 namespace PoproshaykaBot.Core.Tests.Server.Endpoints;
@@ -32,7 +34,7 @@ public sealed class ChatSettingsEndpointTests
 
     private string _tempDir = null!;
 
-    private ObsChatStore CreateStore(ObsChatSettings? initial = null)
+    private (ObsChatStore Store, InMemoryEventBus Bus) CreateStoreWithBus(ObsChatSettings? initial = null)
     {
         var bus = new InMemoryEventBus(NullLogger<InMemoryEventBus>.Instance);
         var path = Path.Combine(_tempDir, "obs-chat.json");
@@ -43,7 +45,17 @@ public sealed class ChatSettingsEndpointTests
             store.Save(initial);
         }
 
-        return store;
+        return (store, bus);
+    }
+
+    private ObsChatStore CreateStore(ObsChatSettings? initial = null)
+    {
+        return CreateStoreWithBus(initial).Store;
+    }
+
+    private static StringContent JsonBody(string json)
+    {
+        return new(json, Encoding.UTF8, "application/json");
     }
 
     [Test]
@@ -102,5 +114,129 @@ public sealed class ChatSettingsEndpointTests
             Assert.That(doc.GetProperty("fontSize").GetString(), Is.EqualTo("22px"));
             Assert.That(doc.GetProperty("fontWeight").GetString(), Is.EqualTo("bold"));
         }
+    }
+
+    [Test]
+    public async Task PostChatSettings_PersistsAndPublishesEvent()
+    {
+        var (store, bus) = CreateStoreWithBus();
+        var eventTcs = new TaskCompletionSource<ObsChatSettings>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = bus.Subscribe<ChatSettingsChangedEvent>((@event, _) =>
+        {
+            eventTcs.TrySetResult(@event.Settings);
+            return Task.CompletedTask;
+        });
+
+        using var server = await EndpointTestServer.CreateAsync(services =>
+            {
+                services.AddRouting();
+                services.AddSingleton(store);
+            },
+            sp => new ChatSettingsEndpoint(sp.GetRequiredService<ObsChatStore>()));
+
+        var payload = JsonSerializer.Serialize(new ObsChatSettings
+        {
+            MaxMessages = 77,
+            FontSize = 22,
+            FontBold = true,
+            UsernameColor = Color.FromArgb(255, 200, 100, 50),
+            UserMessageAnimation = MessageAnimationType.PopIn,
+            FadeOutAnimationType = MessageAnimationType.Dissolve,
+            MessageLifetimeSeconds = 15,
+        }, JsonStoreOptions.Default);
+
+        using var client = server.CreateClient();
+        using var response = await client.PostAsync("/api/chat-settings", JsonBody(payload));
+
+        var persisted = store.Load();
+        var broadcastTask = await Task.WhenAny(eventTcs.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        var published = broadcastTask == eventTcs.Task ? await eventTcs.Task : null;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(persisted.MaxMessages, Is.EqualTo(77));
+            Assert.That(persisted.FontSize, Is.EqualTo(22));
+            Assert.That(persisted.FontBold, Is.True);
+            Assert.That(persisted.UsernameColor.ToArgb(), Is.EqualTo(Color.FromArgb(255, 200, 100, 50).ToArgb()));
+            Assert.That(persisted.UserMessageAnimation, Is.EqualTo(MessageAnimationType.PopIn));
+            Assert.That(persisted.FadeOutAnimationType, Is.EqualTo(MessageAnimationType.Dissolve));
+            Assert.That(persisted.MessageLifetimeSeconds, Is.EqualTo(15));
+            Assert.That(published, Is.Not.Null, "Событие ChatSettingsChangedEvent должно быть опубликовано");
+            Assert.That(published!.MaxMessages, Is.EqualTo(77));
+        }
+    }
+
+    [Test]
+    public async Task PostChatSettings_ClampsOutOfRangeValuesSilently()
+    {
+        var store = CreateStore();
+
+        using var server = await EndpointTestServer.CreateAsync(services =>
+            {
+                services.AddRouting();
+                services.AddSingleton(store);
+            },
+            sp => new ChatSettingsEndpoint(sp.GetRequiredService<ObsChatStore>()));
+
+        var payload = JsonSerializer.Serialize(new ObsChatSettings
+        {
+            FontSize = 9999,
+            MaxMessages = -5,
+            ScrollPauseAfterUserMs = 1_000_000,
+            UserMessageAnimation = "totally-not-a-real-animation",
+            FadeOutAnimationType = "also-bogus",
+        }, JsonStoreOptions.Default);
+
+        using var client = server.CreateClient();
+        using var response = await client.PostAsync("/api/chat-settings", JsonBody(payload));
+
+        var persisted = store.Load();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(persisted.FontSize, Is.EqualTo(ObsChatRanges.FontSizeMax));
+            Assert.That(persisted.MaxMessages, Is.EqualTo(ObsChatRanges.MaxMessagesMin));
+            Assert.That(persisted.ScrollPauseAfterUserMs, Is.EqualTo(ObsChatRanges.ScrollPauseAfterUserMsMax));
+            Assert.That(persisted.UserMessageAnimation, Is.EqualTo(MessageAnimationType.SlideInRight));
+            Assert.That(persisted.FadeOutAnimationType, Is.EqualTo(MessageAnimationType.FadeOut));
+        }
+    }
+
+    [Test]
+    public async Task PostChatSettings_ReturnsBadRequestForInvalidJson()
+    {
+        var store = CreateStore();
+
+        using var server = await EndpointTestServer.CreateAsync(services =>
+            {
+                services.AddRouting();
+                services.AddSingleton(store);
+            },
+            sp => new ChatSettingsEndpoint(sp.GetRequiredService<ObsChatStore>()));
+
+        using var client = server.CreateClient();
+        using var response = await client.PostAsync("/api/chat-settings", JsonBody("{ this is not json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task PostChatSettings_ReturnsBadRequestForNullBody()
+    {
+        var store = CreateStore();
+
+        using var server = await EndpointTestServer.CreateAsync(services =>
+            {
+                services.AddRouting();
+                services.AddSingleton(store);
+            },
+            sp => new ChatSettingsEndpoint(sp.GetRequiredService<ObsChatStore>()));
+
+        using var client = server.CreateClient();
+        using var response = await client.PostAsync("/api/chat-settings", JsonBody("null"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
     }
 }

--- a/PoproshaykaBot.Core.Tests/Settings/AnimationsDemoUiSyncTests.cs
+++ b/PoproshaykaBot.Core.Tests/Settings/AnimationsDemoUiSyncTests.cs
@@ -1,0 +1,137 @@
+﻿using PoproshaykaBot.Core.Settings.Obs;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace PoproshaykaBot.Core.Tests.Settings;
+
+[TestFixture]
+public sealed class AnimationsDemoUiSyncTests
+{
+    [TestCaseSource(nameof(GetMutableSourceProperties))]
+    public void EveryObsChatSettingsProperty_HasMatchingCfgControl(PropertyInfo prop)
+    {
+        var camelCase = ToCamelCase(prop.Name);
+
+        if (prop.PropertyType == typeof(Color))
+        {
+            var configJs = File.ReadAllText(LocateAsset("animations-demo-config.js"));
+            var pattern = $"""key\s*:\s*['"]{Regex.Escape(camelCase)}['"]""";
+            Assert.That(configJs, Does.Match(pattern));
+
+            return;
+        }
+
+        var html = File.ReadAllText(LocateAsset("animations-demo.html"));
+        var expectedId = "cfg-" + camelCase;
+        var idPattern = $"""\bid\s*=\s*["']{Regex.Escape(expectedId)}["']""";
+        Assert.That(html, Does.Match(idPattern));
+    }
+
+    [TestCaseSource(nameof(GetMutableSourceProperties))]
+    public void EveryObsChatSettingsProperty_IsBoundInConfigJs(PropertyInfo prop)
+    {
+        if (prop.PropertyType == typeof(Color))
+        {
+            return;
+        }
+
+        var camelCase = ToCamelCase(prop.Name);
+        var configJs = File.ReadAllText(LocateAsset("animations-demo-config.js"));
+
+        var bindPattern = $"""bindControl\(\s*['"]cfg-{Regex.Escape(camelCase)}['"]\s*,\s*['"]{Regex.Escape(camelCase)}['"]""";
+        Assert.That(configJs, Does.Match(bindPattern));
+    }
+
+    [TestCaseSource(nameof(GetIntegerSourceProperties))]
+    public void EveryIntegerObsChatSettingsProperty_HasEntryInRangesSchema(PropertyInfo prop)
+    {
+        var camelCase = ToCamelCase(prop.Name);
+
+        Assert.That(ObsChatRangesSchema.All, Does.ContainKey(camelCase));
+    }
+
+    [Test]
+    public void EveryRangesSchemaKey_MapsToIntegerObsChatSettingsProperty()
+    {
+        var integerProperties = typeof(ObsChatSettings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(int))
+            .Select(p => ToCamelCase(p.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var key in ObsChatRangesSchema.All.Keys)
+        {
+            Assert.That(integerProperties, Does.Contain(key));
+        }
+    }
+
+    [Test]
+    public void RangeFieldsInConfigJs_MatchObsChatRangesSchemaKeys()
+    {
+        var configJs = File.ReadAllText(LocateAsset("animations-demo-config.js"));
+        var jsKeys = ExtractRangeFieldKeys(configJs);
+
+        Assert.That(jsKeys, Is.EquivalentTo(ObsChatRangesSchema.All.Keys));
+    }
+
+    private static IReadOnlyList<string> ExtractRangeFieldKeys(string jsSource)
+    {
+        var arrayMatch = Regex.Match(jsSource, @"const\s+rangeFields\s*=\s*\[(?<body>[\s\S]*?)\];");
+        if (!arrayMatch.Success)
+        {
+            throw new InvalidOperationException("Не нашли массив 'rangeFields' в animations-demo-config.js. "
+                                                + "Возможно, его переименовали — обновите тест или верните прежнее имя.");
+        }
+
+        return Regex.Matches(arrayMatch.Groups["body"].Value,
+                """\[\s*['"][^'"]+['"]\s*,\s*['"](?<key>[^'"]+)['"]\s*\]""")
+            .Select(m => m.Groups["key"].Value)
+            .ToArray();
+    }
+
+    private static IEnumerable<PropertyInfo> GetMutableSourceProperties()
+    {
+        return typeof(ObsChatSettings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p is { CanRead: true, CanWrite: true });
+    }
+
+    private static IEnumerable<PropertyInfo> GetIntegerSourceProperties()
+    {
+        return GetMutableSourceProperties().Where(p => p.PropertyType == typeof(int));
+    }
+
+    private static string ToCamelCase(string name)
+    {
+        if (string.IsNullOrEmpty(name) || char.IsLower(name[0]))
+        {
+            return name;
+        }
+
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+
+    private static string LocateAsset(string fileName)
+    {
+        var current = AppContext.BaseDirectory;
+
+        for (var i = 0; i < 8; i++)
+        {
+            var candidate = Path.Combine(current, "PoproshaykaBot.Core", "Assets", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            var parent = Directory.GetParent(current);
+            if (parent == null)
+            {
+                break;
+            }
+
+            current = parent.FullName;
+        }
+
+        throw new FileNotFoundException($"Не найден ассет {fileName} (нужен для проверки UI-полноты демки).");
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Settings/ObsChatSettingsControlColorTests.cs
+++ b/PoproshaykaBot.Core.Tests/Settings/ObsChatSettingsControlColorTests.cs
@@ -18,7 +18,7 @@ public sealed class ObsChatSettingsControlColorTests
             TextColor = Color.FromArgb(255, 255, 255, 255),
         };
 
-        Assert.DoesNotThrow(() => control.LoadSettings(settings));
+        Assert.DoesNotThrow(() => control.LoadSettings(settings, 8080));
     }
 
     [Test]
@@ -34,7 +34,7 @@ public sealed class ObsChatSettingsControlColorTests
             TimestampColor = Color.FromArgb(255, 153, 153, 153),
         };
 
-        control.LoadSettings(saved);
+        control.LoadSettings(saved, 8080);
         var written = new ObsChatSettings();
         control.SaveSettings(written);
 
@@ -54,7 +54,7 @@ public sealed class ObsChatSettingsControlColorTests
         using var control = new ObsChatSettingsControl();
         var defaults = new ObsChatSettings();
 
-        Assert.DoesNotThrow(() => control.LoadSettings(defaults));
+        Assert.DoesNotThrow(() => control.LoadSettings(defaults, 8080));
 
         var saved = new ObsChatSettings();
         control.SaveSettings(saved);
@@ -72,7 +72,7 @@ public sealed class ObsChatSettingsControlColorTests
             TextColor = Color.FromArgb(255, 255, 255, 255),
         };
 
-        control.LoadSettings(settings);
+        control.LoadSettings(settings, 8080);
 
         var button = (Button)typeof(ObsChatSettingsControl)
             .GetField("_backgroundColorButton", BindingFlags.NonPublic | BindingFlags.Instance)!
@@ -91,7 +91,7 @@ public sealed class ObsChatSettingsControlColorTests
             BackgroundColor = Color.FromArgb(255, 18, 52, 86),
         };
 
-        control.LoadSettings(settings);
+        control.LoadSettings(settings, 8080);
 
         var button = (Button)typeof(ObsChatSettingsControl)
             .GetField("_backgroundColorButton", BindingFlags.NonPublic | BindingFlags.Instance)!

--- a/PoproshaykaBot.Core.Tests/Twitch/Chat/EventSubChatMessageMapperTests.cs
+++ b/PoproshaykaBot.Core.Tests/Twitch/Chat/EventSubChatMessageMapperTests.cs
@@ -1,0 +1,62 @@
+﻿using PoproshaykaBot.Core.Twitch.Chat;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Tests.Twitch.Chat;
+
+[TestFixture]
+public sealed class EventSubChatMessageMapperTests
+{
+    private const string BotId = "bot-42";
+    private const string ViewerId = "viewer-7";
+
+    private static JsonElement Payload(string chatterUserId)
+    {
+        var json = $$"""
+                     {
+                       "event": {
+                         "broadcaster_user_login": "channel",
+                         "message_id": "msg-1",
+                         "chatter_user_id": "{{chatterUserId}}",
+                         "chatter_user_login": "chatter",
+                         "chatter_user_name": "Chatter",
+                         "message": { "text": "привет" },
+                         "badges": []
+                       }
+                     }
+                     """;
+
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    [Test]
+    public void Map_WhenChatterIsBot_MarksIsBotTrue()
+    {
+        var message = EventSubChatMessageMapper.Map(Payload(BotId), BotId);
+
+        Assert.That(message.IsBot, Is.True);
+    }
+
+    [Test]
+    public void Map_WhenChatterIsViewer_LeavesIsBotFalse()
+    {
+        var message = EventSubChatMessageMapper.Map(Payload(ViewerId), BotId);
+
+        Assert.That(message.IsBot, Is.False);
+    }
+
+    [Test]
+    public void Map_WhenBotIdIsNull_LeavesIsBotFalse()
+    {
+        var message = EventSubChatMessageMapper.Map(Payload(BotId), null);
+
+        Assert.That(message.IsBot, Is.False);
+    }
+
+    [Test]
+    public void Map_WhenBotIdIsEmpty_LeavesIsBotFalse()
+    {
+        var message = EventSubChatMessageMapper.Map(Payload(BotId), string.Empty);
+
+        Assert.That(message.IsBot, Is.False);
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Update/UpdateCheckerTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateCheckerTests.cs
@@ -5,16 +5,33 @@ namespace PoproshaykaBot.Core.Tests.Update;
 [TestFixture]
 public sealed class UpdateCheckerTests
 {
+    private static ReleaseAsset Asset(string name)
+    {
+        return new(name, "https://example/download/" + name, 100, "application/octet-stream");
+    }
+
     private static ReleaseInfo Release(
         string tag = "v3.1.0.7",
         bool prerelease = false,
         bool draft = false,
-        string assetName = "PoproshaykaBot-v3.1.0.7-x64-portable.exe")
+        string assetName = "PoproshaykaBot-v3.1.0.7-x64-portable.exe",
+        string arch = "x64",
+        bool includeChecksums = true,
+        bool includeRuntime = true)
     {
-        return new(tag, "https://example/notes", "body", prerelease, draft,
-        [
-            new(assetName, "https://example/download/" + assetName, 100, "application/octet-stream"),
-        ]);
+        var assets = new List<ReleaseAsset> { Asset(assetName) };
+
+        if (includeChecksums)
+        {
+            assets.Add(Asset("SHA256SUMS-" + arch + ".txt"));
+        }
+
+        if (includeRuntime)
+        {
+            assets.Add(Asset("RUNTIME-" + arch + ".txt"));
+        }
+
+        return new(tag, "https://example/notes", "body", prerelease, draft, assets);
     }
 
     private static UpdateChecker CreateChecker(
@@ -95,6 +112,8 @@ public sealed class UpdateCheckerTests
             [
                 new("PoproshaykaBot-v3.1.0.7-x64-portable.exe", "p", 1, "application/octet-stream"),
                 new("PoproshaykaBot-v3.1.0.7-x64.exe", "f", 2, "application/octet-stream"),
+                new("SHA256SUMS-x64.txt", "s", 3, "text/plain"),
+                new("RUNTIME-x64.txt", "r", 4, "text/plain"),
             ]));
 
         var candidate = await CreateChecker(client, kind: UpdateKind.FrameworkDependent)
@@ -127,5 +146,41 @@ public sealed class UpdateCheckerTests
         var candidate = await CreateChecker(client, arch: "x64").CheckAsync(null, CancellationToken.None);
 
         Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenChecksumsAssetMissing()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release(includeChecksums: false));
+
+        var candidate = await CreateChecker(client).CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenRuntimeAssetMissing_ForFrameworkDependent()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client
+            .GetLatestReleaseAsync(Arg.Any<CancellationToken>())
+            .Returns(Release(assetName: "PoproshaykaBot-v3.1.0.7-x64.exe", includeRuntime: false));
+
+        var candidate = await CreateChecker(client, kind: UpdateKind.FrameworkDependent)
+            .CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_Portable_DoesNotRequireRuntimeAsset()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release(includeRuntime: false));
+
+        var candidate = await CreateChecker(client).CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Not.Null);
     }
 }

--- a/PoproshaykaBot.Core.Tests/Update/UpdateCheckerTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateCheckerTests.cs
@@ -1,0 +1,131 @@
+﻿using PoproshaykaBot.Core.Update;
+
+namespace PoproshaykaBot.Core.Tests.Update;
+
+[TestFixture]
+public sealed class UpdateCheckerTests
+{
+    private static ReleaseInfo Release(
+        string tag = "v3.1.0.7",
+        bool prerelease = false,
+        bool draft = false,
+        string assetName = "PoproshaykaBot-v3.1.0.7-x64-portable.exe")
+    {
+        return new(tag, "https://example/notes", "body", prerelease, draft,
+        [
+            new(assetName, "https://example/download/" + assetName, 100, "application/octet-stream"),
+        ]);
+    }
+
+    private static UpdateChecker CreateChecker(
+        IGitHubReleaseClient client,
+        string currentVersion = "3.1.0.6",
+        string arch = "x64",
+        UpdateKind kind = UpdateKind.Portable)
+    {
+        var environment = Substitute.For<IUpdateEnvironment>();
+        environment.CurrentVersion.Returns(Version.Parse(currentVersion));
+        environment.ArchitectureMoniker.Returns(arch);
+        environment.Kind.Returns(kind);
+
+        return new(client, environment, NullLogger<UpdateChecker>.Instance);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsCandidate_WhenNewerVersionAvailable()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release());
+
+        var candidate = await CreateChecker(client).CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(candidate!.Version, Is.EqualTo(Version.Parse("3.1.0.7")));
+            Assert.That(candidate.NotesUrl, Is.EqualTo("https://example/notes"));
+            Assert.That(candidate.Asset.Name, Is.EqualTo("PoproshaykaBot-v3.1.0.7-x64-portable.exe"));
+        }
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenAlreadyCurrent()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release(tag: "v3.1.0.6"));
+
+        var candidate = await CreateChecker(client).CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenVersionSkipped()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release());
+
+        var candidate = await CreateChecker(client).CheckAsync("3.1.0.7", CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_ForPrereleaseOrDraft()
+    {
+        var prereleaseClient = Substitute.For<IGitHubReleaseClient>();
+        prereleaseClient.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release(prerelease: true));
+
+        var draftClient = Substitute.For<IGitHubReleaseClient>();
+        draftClient.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release(draft: true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await CreateChecker(prereleaseClient).CheckAsync(null, CancellationToken.None), Is.Null);
+            Assert.That(await CreateChecker(draftClient).CheckAsync(null, CancellationToken.None), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task CheckAsync_FrameworkDependent_PicksPlainExe()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>())
+            .Returns(new ReleaseInfo("v3.1.0.7", "https://example/notes", "body", false, false,
+            [
+                new("PoproshaykaBot-v3.1.0.7-x64-portable.exe", "p", 1, "application/octet-stream"),
+                new("PoproshaykaBot-v3.1.0.7-x64.exe", "f", 2, "application/octet-stream"),
+            ]));
+
+        var candidate = await CreateChecker(client, kind: UpdateKind.FrameworkDependent)
+            .CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Not.Null);
+        Assert.That(candidate!.Asset.Name, Is.EqualTo("PoproshaykaBot-v3.1.0.7-x64.exe"));
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenUnsupportedBuild()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client.GetLatestReleaseAsync(Arg.Any<CancellationToken>()).Returns(Release());
+
+        var candidate = await CreateChecker(client, kind: UpdateKind.Unsupported)
+            .CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckAsync_ReturnsNull_WhenNoArchitectureAsset()
+    {
+        var client = Substitute.For<IGitHubReleaseClient>();
+        client
+            .GetLatestReleaseAsync(Arg.Any<CancellationToken>())
+            .Returns(Release(assetName: "PoproshaykaBot-v3.1.0.7-x86-portable.exe"));
+
+        var candidate = await CreateChecker(client, arch: "x64").CheckAsync(null, CancellationToken.None);
+
+        Assert.That(candidate, Is.Null);
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Update/UpdateRepositoryTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateRepositoryTests.cs
@@ -1,0 +1,48 @@
+﻿using PoproshaykaBot.Core.Update;
+
+namespace PoproshaykaBot.Core.Tests.Update;
+
+[TestFixture]
+public sealed class UpdateRepositoryTests
+{
+    [TestCase("MaxNagibator/PoproshaykaBot")]
+    [TestCase("a/b")]
+    [TestCase("user-name/repo.name_1")]
+    [TestCase("Org123/My-Repo.2")]
+    public void IsValidSlug_AcceptsWellFormed(string slug)
+    {
+        Assert.That(UpdateRepository.IsValidSlug(slug), Is.True);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("noslash")]
+    [TestCase("a/b/c")]
+    [TestCase("a//b")]
+    [TestCase("/repo")]
+    [TestCase("owner/")]
+    [TestCase("ow ner/repo")]
+    [TestCase("../etc")]
+    [TestCase("owner/..")]
+    [TestCase("https://github.com/a/b")]
+    [TestCase("a/b?x=1")]
+    public void IsValidSlug_RejectsMalformedOrUnsafe(string? slug)
+    {
+        Assert.That(UpdateRepository.IsValidSlug(slug), Is.False);
+    }
+
+    [Test]
+    public void Resolve_PrefersValidOverride_TrimmedOtherwiseFallsBack()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(UpdateRepository.Resolve("Fork/Repo", "Default/Repo"), Is.EqualTo("Fork/Repo"));
+            Assert.That(UpdateRepository.Resolve("  Fork/Repo  ", "Default/Repo"), Is.EqualTo("Fork/Repo"));
+            Assert.That(UpdateRepository.Resolve(null, "Default/Repo"), Is.EqualTo("Default/Repo"));
+            Assert.That(UpdateRepository.Resolve("   ", "Default/Repo"), Is.EqualTo("Default/Repo"));
+            Assert.That(UpdateRepository.Resolve("garbage", "Default/Repo"), Is.EqualTo("Default/Repo"));
+            Assert.That(UpdateRepository.Resolve("../escape", "Default/Repo"), Is.EqualTo("Default/Repo"));
+        }
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Update/UpdateRuntimeTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateRuntimeTests.cs
@@ -1,0 +1,26 @@
+﻿using PoproshaykaBot.Core.Update;
+
+namespace PoproshaykaBot.Core.Tests.Update;
+
+[TestFixture]
+public sealed class UpdateRuntimeTests
+{
+    [TestCase("net8.0-windows", 8)]
+    [TestCase("net8.0", 8)]
+    [TestCase("net10.0-windows", 10)]
+    [TestCase(".NETCoreApp,Version=v8.0", 8)]
+    [TestCase(".NETCoreApp,Version=v9.0", 9)]
+    public void ParseMajor_ExtractsRuntimeMajor(string value, int expected)
+    {
+        Assert.That(UpdateRuntime.ParseMajor(value), Is.EqualTo(expected));
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase(null)]
+    [TestCase("garbage")]
+    public void ParseMajor_ReturnsNull_ForInvalidInput(string? value)
+    {
+        Assert.That(UpdateRuntime.ParseMajor(value), Is.Null);
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Update/UpdateSwapAndFinalizeTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateSwapAndFinalizeTests.cs
@@ -1,0 +1,54 @@
+﻿using PoproshaykaBot.Core.Update;
+
+namespace PoproshaykaBot.Core.Tests.Update;
+
+[TestFixture]
+public sealed class UpdateSwapAndFinalizeTests
+{
+    [Test]
+    public void Plan_DerivesBackupAndKeepsStaged()
+    {
+        var plan = UpdateSwapPlanner.Plan(@"C:\app\Bot.exe", @"C:\app\update\Bot.new.exe");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(plan.CurrentExecutable, Is.EqualTo(@"C:\app\Bot.exe"));
+            Assert.That(plan.BackupExecutable, Is.EqualTo(@"C:\app\Bot.exe.old"));
+            Assert.That(plan.StagedExecutable, Is.EqualTo(@"C:\app\update\Bot.new.exe"));
+        }
+    }
+
+    [Test]
+    public void Finalizer_RemovesBackupAndStagingDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "poproshayka-update-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var executablePath = Path.Combine(root, "Bot.exe");
+            var backupPath = executablePath + ".old";
+            var stagingDirectory = Path.Combine(root, "update");
+
+            File.WriteAllText(executablePath, "current");
+            File.WriteAllText(backupPath, "previous");
+            Directory.CreateDirectory(stagingDirectory);
+            File.WriteAllText(Path.Combine(stagingDirectory, "apply-update.json"), "{}");
+
+            UpdateFinalizer.Run(stagingDirectory, executablePath, NullLogger.Instance);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.Exists(backupPath), Is.False);
+                Assert.That(Directory.Exists(stagingDirectory), Is.False);
+                Assert.That(File.Exists(executablePath), Is.True, "Текущий исполняемый файл не должен удаляться");
+            }
+
+            Assert.DoesNotThrow(() => UpdateFinalizer.Run(stagingDirectory, executablePath, NullLogger.Instance));
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/PoproshaykaBot.Core.Tests/Update/UpdateVersioningTests.cs
+++ b/PoproshaykaBot.Core.Tests/Update/UpdateVersioningTests.cs
@@ -1,0 +1,89 @@
+﻿using PoproshaykaBot.Core.Update;
+
+namespace PoproshaykaBot.Core.Tests.Update;
+
+[TestFixture]
+public sealed class UpdateVersioningTests
+{
+    [TestCase("v3.1.0.7", "3.1.0.7")]
+    [TestCase("3.1.0.6", "3.1.0.6")]
+    [TestCase("V3.1.0.6+abcdef", "3.1.0.6")]
+    [TestCase(" v3.1.0 ", "3.1.0.0")]
+    [TestCase("3.2.0-rc1", "3.2.0.0")]
+    public void TryParseTag_ParsesSupportedFormats(string raw, string expected)
+    {
+        var parsed = UpdateVersioning.TryParseTag(raw, out var version);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(parsed, Is.True);
+            Assert.That(version, Is.EqualTo(Version.Parse(expected)));
+        }
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("not-a-version")]
+    [TestCase(null)]
+    public void TryParseTag_RejectsInvalidInput(string? raw)
+    {
+        Assert.That(UpdateVersioning.TryParseTag(raw, out _), Is.False);
+    }
+
+    [Test]
+    public void SelectAsset_Portable_PicksPortableForArchitecture()
+    {
+        var release = new ReleaseInfo("v3.1.0.7", "url", "body", false, false,
+        [
+            new("PoproshaykaBot-v3.1.0.7-x86-portable.exe", "u1", 1, "application/octet-stream"),
+            new("PoproshaykaBot-v3.1.0.7-x64-portable.exe", "u2", 2, "application/octet-stream"),
+            new("PoproshaykaBot-v3.1.0.7-x64.exe", "u3", 3, "application/octet-stream"),
+        ]);
+
+        var asset = UpdateVersioning.SelectAsset(release, "x64", UpdateKind.Portable);
+
+        Assert.That(asset, Is.Not.Null);
+        Assert.That(asset!.Name, Is.EqualTo("PoproshaykaBot-v3.1.0.7-x64-portable.exe"));
+    }
+
+    [Test]
+    public void SelectAsset_FrameworkDependent_PicksPlainExeNotPortable()
+    {
+        var release = new ReleaseInfo("v3.1.0.7", "url", "body", false, false,
+        [
+            new("PoproshaykaBot-v3.1.0.7-x64-portable.exe", "u1", 1, "application/octet-stream"),
+            new("PoproshaykaBot-v3.1.0.7-x64.exe", "u2", 2, "application/octet-stream"),
+        ]);
+
+        var asset = UpdateVersioning.SelectAsset(release, "x64", UpdateKind.FrameworkDependent);
+
+        Assert.That(asset, Is.Not.Null);
+        Assert.That(asset!.Name, Is.EqualTo("PoproshaykaBot-v3.1.0.7-x64.exe"));
+    }
+
+    [Test]
+    public void SelectAsset_ReturnsNull_ForUnsupportedKindOrNoMatch()
+    {
+        var release = new ReleaseInfo("v3.1.0.7", "url", "body", false, false,
+        [
+            new("PoproshaykaBot-v3.1.0.7-x86-portable.exe", "u1", 1, "application/octet-stream"),
+        ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(UpdateVersioning.SelectAsset(release, "x64", UpdateKind.Portable), Is.Null);
+            Assert.That(UpdateVersioning.SelectAsset(release, "x86", UpdateKind.Unsupported), Is.Null);
+        }
+    }
+
+    [Test]
+    public void IsNewer_ComparesVersions()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(UpdateVersioning.IsNewer(Version.Parse("3.1.0.7"), Version.Parse("3.1.0.6")), Is.True);
+            Assert.That(UpdateVersioning.IsNewer(Version.Parse("3.1.0.6"), Version.Parse("3.1.0.6")), Is.False);
+            Assert.That(UpdateVersioning.IsNewer(Version.Parse("3.1.0.5"), Version.Parse("3.1.0.6")), Is.False);
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Assets/animations-demo-config.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo-config.js
@@ -1,48 +1,7 @@
 ﻿(function () {
     'use strict';
 
-    const STORAGE_KEY = 'poproshaykabot.demo.chatSettings.v1';
-
-    const defaults = {
-        backgroundColor: { a: 179, r: 0, g: 0, b: 0 },
-        textColor: { a: 255, r: 255, g: 255, b: 255 },
-        usernameColor: { a: 255, r: 145, g: 70, b: 255 },
-        systemMessageColor: { a: 255, r: 255, g: 204, b: 0 },
-        timestampColor: { a: 255, r: 153, g: 153, b: 153 },
-        fontFamily: '"Motiva Sans", "Inter", "Noto Sans", Arial, sans-serif',
-        fontSize: 14,
-        fontBold: false,
-        padding: 5,
-        margin: 5,
-        borderRadius: 5,
-        animationDuration: 300,
-        enableAnimations: true,
-        maxMessages: 50,
-        showTimestamp: true,
-        emoteSizePixels: 28,
-        badgeSizePixels: 18,
-        showUserAvatars: false,
-        userAvatarSizePixels: 32,
-        showUserTypeBorders: true,
-        highlightFirstTimeUsers: true,
-        highlightMentions: true,
-        enableMessageShadows: true,
-        enableSpecialEffects: true,
-        enableSmoothScroll: true,
-        scrollAnimationDuration: 300,
-        autoScrollEnabled: true,
-        scrollToBottomThreshold: 100,
-        scrollPauseAfterUserMs: 3000,
-        userMessageAnimation: 'slide-in-right',
-        botMessageAnimation: 'fade-in-up',
-        systemMessageAnimation: 'fade-in-up',
-        broadcasterMessageAnimation: 'slide-in-left',
-        firstTimeUserMessageAnimation: 'bounce-in',
-        enableMessageFadeOut: true,
-        messageLifetimeSeconds: 30,
-        fadeOutAnimationType: 'fade-out',
-        fadeOutAnimationDurationMs: 1000,
-    };
+    const STORAGE_KEY = 'poproshaykabot.demo.chatSettings.v2';
 
     const colorFields = [
         { key: 'backgroundColor', label: 'Фон сообщения' },
@@ -82,103 +41,42 @@
 
     const fontWeightVar = '--chat-font-weight';
 
-    const entryAnimList = [
-        ['no-animation', 'Без анимации'],
-        ['slide-in-right', 'Скольжение справа'],
-        ['slide-in-left', 'Скольжение слева'],
-        ['fade-in-up', 'Затухание сверху'],
-        ['bounce-in', 'Прыжок'],
-        ['pop-in', 'Поп-ап с упругостью'],
-        ['rubber-band', 'Резиновая лента'],
-        ['tada', 'Та-да!'],
-        ['zoom-blur-in', 'Кинонаезд с размытием'],
-        ['neon-pulse-in', 'Неоновая вспышка'],
-        ['materialize', 'Материализация'],
-        ['glitch-in', 'Глитч'],
-        ['power-up', 'Усиление снизу'],
-        ['slam-in', 'Удар сверху'],
-        ['notification-bell', 'Звон уведомления'],
-        ['hologram', 'Голограмма'],
-        ['flip-in-x', 'Переворот по горизонтали'],
-        ['roll-in', 'Вкатывание'],
-        ['coin-flip', 'Подброс монеты'],
-        ['swoop-in', 'Налёт по диагонали'],
+    const rangeFields = [
+        ['cfg-fontSize', 'fontSize'],
+        ['cfg-padding', 'padding'],
+        ['cfg-margin', 'margin'],
+        ['cfg-borderRadius', 'borderRadius'],
+        ['cfg-maxMessages', 'maxMessages'],
+        ['cfg-emoteSizePixels', 'emoteSizePixels'],
+        ['cfg-badgeSizePixels', 'badgeSizePixels'],
+        ['cfg-userAvatarSizePixels', 'userAvatarSizePixels'],
+        ['cfg-scrollAnimationDuration', 'scrollAnimationDuration'],
+        ['cfg-scrollToBottomThreshold', 'scrollToBottomThreshold'],
+        ['cfg-scrollPauseAfterUserMs', 'scrollPauseAfterUserMs'],
+        ['cfg-animationDuration', 'animationDuration'],
+        ['cfg-messageLifetimeSeconds', 'messageLifetimeSeconds'],
+        ['cfg-fadeOutAnimationDurationMs', 'fadeOutAnimationDurationMs'],
     ];
 
-    const exitAnimList = [
-        ['no-animation', 'Без анимации'],
-        ['fade-out', 'Исчезновение'],
-        ['slide-out-left', 'Выскользнуть влево'],
-        ['slide-out-right', 'Выскользнуть вправо'],
-        ['scale-down', 'Уменьшение'],
-        ['shrink-up', 'Свернуться вверх'],
-        ['dissolve', 'Растворение в пыль'],
-        ['slide-out-up', 'Выскользнуть вверх'],
-        ['slide-out-down', 'Выскользнуть вниз'],
-        ['rotate-out', 'Поворот с уходом'],
-        ['pixelate-out', 'Пикселизация'],
-    ];
+    let settings = null;
+    let serverSnapshot = null;
+    let schema = null;
+    let animations = null;
+    let isDirty = false;
+    let bootstrapFailed = false;
+
+    const drawer = document.getElementById('config-drawer');
+    const toggleButton = document.getElementById('config-toggle');
+    const closeButton = document.getElementById('config-close');
+    const revertButton = document.getElementById('config-revert');
+    const pushButton = document.getElementById('config-push');
+    const colorsContainer = document.getElementById('config-colors');
+    const statusEl = document.getElementById('config-status');
+    const dirtyEl = document.getElementById('config-dirty');
+    const errorEl = document.getElementById('config-error');
 
     function deepClone(value) {
         return JSON.parse(JSON.stringify(value));
-    }
-
-    function normalizeColor(raw) {
-        if (!raw) return null;
-        if (typeof raw === 'string') {
-            const hex = raw.startsWith('#') ? raw.slice(1) : raw;
-            if (hex.length === 6) {
-                return {
-                    a: 255,
-                    r: parseInt(hex.slice(0, 2), 16),
-                    g: parseInt(hex.slice(2, 4), 16),
-                    b: parseInt(hex.slice(4, 6), 16),
-                };
-            }
-            if (hex.length === 8) {
-                return {
-                    a: parseInt(hex.slice(0, 2), 16),
-                    r: parseInt(hex.slice(2, 4), 16),
-                    g: parseInt(hex.slice(4, 6), 16),
-                    b: parseInt(hex.slice(6, 8), 16),
-                };
-            }
-            return null;
-        }
-        if (typeof raw === 'object') {
-            const clamp = (v, d) => {
-                const n = Number(v);
-                return Number.isFinite(n) ? Math.max(0, Math.min(255, Math.round(n))) : d;
-            };
-            return {
-                a: clamp(raw.a !== undefined ? raw.a : raw.A, 255),
-                r: clamp(raw.r !== undefined ? raw.r : raw.R, 0),
-                g: clamp(raw.g !== undefined ? raw.g : raw.G, 0),
-                b: clamp(raw.b !== undefined ? raw.b : raw.B, 0),
-            };
-        }
-        return null;
-    }
-
-    function mergeWithDefaults(incoming) {
-        const result = deepClone(defaults);
-        if (!incoming || typeof incoming !== 'object') return result;
-        Object.keys(result).forEach(key => {
-            if (incoming[key] === undefined || incoming[key] === null) return;
-            const def = result[key];
-            if (def && typeof def === 'object' && 'a' in def) {
-                const c = normalizeColor(incoming[key]);
-                if (c) result[key] = c;
-            } else if (typeof def === 'boolean') {
-                result[key] = Boolean(incoming[key]);
-            } else if (typeof def === 'number') {
-                const n = Number(incoming[key]);
-                if (Number.isFinite(n)) result[key] = Math.round(n);
-            } else {
-                result[key] = String(incoming[key]);
-            }
-        });
-        return result;
     }
 
     function colorToCss(color) {
@@ -191,30 +89,81 @@
         return '#' + hex(color.r) + hex(color.g) + hex(color.b);
     }
 
-    function loadSettings() {
+    function settingsEqual(a, b) {
+        return JSON.stringify(a) === JSON.stringify(b);
+    }
+
+    function readDraftFromStorage() {
         try {
             const raw = globalThis.localStorage.getItem(STORAGE_KEY);
-            if (!raw) return deepClone(defaults);
-            return mergeWithDefaults(JSON.parse(raw));
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object' || !parsed.draft) return null;
+            return parsed.draft;
         } catch (e) {
-            console.warn('Не удалось прочитать настройки демо из localStorage:', e);
-            return deepClone(defaults);
+            console.warn('Не удалось прочитать черновик из localStorage:', e);
+            return null;
         }
     }
 
-    function saveSettings() {
+    function writeDraftToStorage() {
         try {
-            globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+            globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ draft: settings }));
         } catch (e) {
-            console.warn('Не удалось сохранить настройки демо в localStorage:', e);
+            console.warn('Не удалось сохранить черновик в localStorage:', e);
         }
     }
 
-    const settings = loadSettings();
+    function clearDraftStorage() {
+        try {
+            globalThis.localStorage.removeItem(STORAGE_KEY);
+        } catch (e) {
+            console.warn('Не удалось очистить черновик в localStorage:', e);
+        }
+    }
+
+    function markDirty() {
+        isDirty = true;
+        writeDraftToStorage();
+        renderDirtyBanner();
+    }
+
+    function markClean(newServerSnapshot) {
+        isDirty = false;
+        serverSnapshot = deepClone(newServerSnapshot);
+        clearDraftStorage();
+        renderDirtyBanner();
+    }
+
+    function renderDirtyBanner() {
+        if (!dirtyEl) return;
+        if (isDirty) {
+            dirtyEl.hidden = false;
+            dirtyEl.textContent = '● Черновик не отправлен в OBS. Нажмите «Применить к OBS» или «С сервера», чтобы отбросить.';
+        } else {
+            dirtyEl.hidden = true;
+            dirtyEl.textContent = '';
+        }
+    }
+
+    function showError(message) {
+        if (!errorEl) return;
+        errorEl.hidden = false;
+        errorEl.textContent = message;
+    }
+
+    function clearError() {
+        if (!errorEl) return;
+        errorEl.hidden = true;
+        errorEl.textContent = '';
+    }
 
     function applySettings() {
+        if (!settings) return;
+
         const root = document.documentElement;
         Object.keys(cssVarMap).forEach(key => {
+            if (settings[key] === undefined || settings[key] === null) return;
             const entry = cssVarMap[key];
             root.style.setProperty(entry[0], entry[1](settings[key]));
         });
@@ -231,14 +180,6 @@
             });
         });
     }
-
-    const drawer = document.getElementById('config-drawer');
-    const toggleButton = document.getElementById('config-toggle');
-    const closeButton = document.getElementById('config-close');
-    const resetButton = document.getElementById('config-reset');
-    const pushButton = document.getElementById('config-push');
-    const colorsContainer = document.getElementById('config-colors');
-    const statusEl = document.getElementById('config-status');
 
     function buildColorControls() {
         colorsContainer.replaceChildren();
@@ -274,6 +215,7 @@
 
             const sync = () => {
                 const current = settings[key];
+                if (!current) return;
                 const hex = colorToHex(current);
                 if (colorInput.value.toLowerCase() !== hex) colorInput.value = hex;
                 if (alphaInput.value !== String(current.a)) alphaInput.value = String(current.a);
@@ -304,14 +246,31 @@
 
     function populateAnimationSelects() {
         document.querySelectorAll('select[data-kind]').forEach(sel => {
-            const list = sel.dataset.kind === 'exit' ? exitAnimList : entryAnimList;
+            const list = sel.dataset.kind === 'exit' ? animations.exit : animations.entry;
             sel.replaceChildren();
-            list.forEach(pair => {
-                const opt = document.createElement('option');
-                opt.value = pair[0];
-                opt.textContent = pair[1];
-                sel.appendChild(opt);
+            list.forEach(opt => {
+                const node = document.createElement('option');
+                node.value = opt.value;
+                node.textContent = opt.label;
+                sel.appendChild(node);
             });
+        });
+    }
+
+    function applySchemaToSliders() {
+        rangeFields.forEach(pair => {
+            const id = pair[0];
+            const settingKey = pair[1];
+            const el = document.getElementById(id);
+            if (!el) return;
+            const range = schema[settingKey];
+            if (!range) {
+                console.warn('Схема не содержит диапазона для', settingKey);
+                return;
+            }
+            el.min = String(range.min);
+            el.max = String(range.max);
+            el.step = String(range.step);
         });
     }
 
@@ -320,9 +279,6 @@
         if (!el) return;
 
         if (kind === 'range' || kind === 'number') {
-            if (el.dataset.min !== undefined) el.min = el.dataset.min;
-            if (el.dataset.max !== undefined) el.max = el.dataset.max;
-            if (el.dataset.step !== undefined) el.step = el.dataset.step;
             el.value = String(settings[settingKey]);
             const valueLabel = document.getElementById(id + '-value');
             const suffix = valueLabel ? valueLabel.dataset.suffix || '' : '';
@@ -397,34 +353,40 @@
 
     function refreshControlsFromSettings() {
         Object.keys(settings).forEach(key => {
-            const def = defaults[key];
-            const isColor = def && typeof def === 'object' && 'a' in def;
+            const value = settings[key];
+            const isColor = value && typeof value === 'object' && 'a' in value;
             if (isColor) {
                 const colorInput = document.getElementById('cfg-' + key);
                 const alphaInput = document.getElementById('cfg-' + key + '-alpha');
                 const swatch = document.getElementById('cfg-' + key + '-swatch');
-                if (colorInput) colorInput.value = colorToHex(settings[key]);
-                if (alphaInput) alphaInput.value = String(settings[key].a);
-                if (swatch) swatch.style.setProperty('--swatch-color', colorToCss(settings[key]));
+                if (colorInput) colorInput.value = colorToHex(value);
+                if (alphaInput) alphaInput.value = String(value.a);
+                if (swatch) swatch.style.setProperty('--swatch-color', colorToCss(value));
                 return;
             }
             const el = document.getElementById('cfg-' + key);
             if (!el) return;
             if (el.type === 'checkbox') {
-                el.checked = Boolean(settings[key]);
+                el.checked = Boolean(value);
             } else if (el.type === 'range' || el.type === 'number') {
-                el.value = String(settings[key]);
+                el.value = String(value);
                 const lbl = document.getElementById(el.id + '-value');
-                if (lbl) lbl.textContent = settings[key] + (lbl.dataset.suffix || '');
+                if (lbl) lbl.textContent = value + (lbl.dataset.suffix || '');
             } else {
-                el.value = String(settings[key]);
+                el.value = String(value);
             }
         });
     }
 
     function onChange() {
         applySettings();
-        saveSettings();
+        if (!settingsEqual(settings, serverSnapshot)) {
+            markDirty();
+        } else {
+            isDirty = false;
+            clearDraftStorage();
+            renderDirtyBanner();
+        }
     }
 
     function setDrawerOpen(open) {
@@ -443,17 +405,137 @@
         }
     }
 
+    function setStatus(text, kind) {
+        statusEl.textContent = text;
+        statusEl.classList.remove('ok', 'error');
+        if (kind) statusEl.classList.add(kind);
+    }
+
+    async function loadFromServer() {
+        const response = await fetch('/api/chat-settings/raw');
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + ' для /api/chat-settings/raw');
+        }
+        return response.json();
+    }
+
+    async function loadSchema() {
+        const response = await fetch('/api/chat-settings/schema');
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + ' для /api/chat-settings/schema');
+        }
+        return response.json();
+    }
+
+    async function loadAnimations() {
+        const response = await fetch('/api/animations');
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + ' для /api/animations');
+        }
+        return response.json();
+    }
+
+    function disableDrawer() {
+        if (pushButton) pushButton.disabled = true;
+        if (revertButton) revertButton.disabled = true;
+    }
+
+    async function bootstrap() {
+        try {
+            const [rawValues, rangesSchema, animationsList] = await Promise.all([
+                loadFromServer(),
+                loadSchema(),
+                loadAnimations(),
+            ]);
+            serverSnapshot = rawValues;
+            schema = rangesSchema;
+            animations = animationsList;
+        } catch (e) {
+            console.error('Bootstrap демки провалился:', e);
+            showError('Не удалось загрузить настройки с сервера: ' + (e && e.message ? e.message : e)
+                + '. Контролы заблокированы — запустите бота или проверьте порт HTTP-сервера.');
+            bootstrapFailed = true;
+            disableDrawer();
+            return;
+        }
+
+        const draft = readDraftFromStorage();
+        if (draft && typeof draft === 'object') {
+            settings = Object.assign({}, serverSnapshot, draft);
+            if (!settingsEqual(settings, serverSnapshot)) {
+                isDirty = true;
+            }
+        } else {
+            settings = deepClone(serverSnapshot);
+        }
+
+        populateAnimationSelects();
+        applySchemaToSliders();
+        buildColorControls();
+        bindAll();
+        refreshControlsFromSettings();
+        applySettings();
+        renderDirtyBanner();
+        subscribeToSse();
+    }
+
+    function rebuildAfterServerUpdate(newSnapshot) {
+        serverSnapshot = deepClone(newSnapshot);
+        if (isDirty) {
+            setStatus('Сервер прислал новые настройки — ваш черновик сохранён. Кнопка ↺ загрузит обновлённую версию.', 'ok');
+            return;
+        }
+        settings = deepClone(newSnapshot);
+        refreshControlsFromSettings();
+        applySettings();
+        setStatus('Настройки обновлены сервером.', 'ok');
+    }
+
+    function subscribeToSse() {
+        if (typeof EventSource === 'undefined') return;
+        try {
+            const source = new EventSource('/events');
+            source.addEventListener('chat_settings_changed_raw', function (event) {
+                try {
+                    const payload = JSON.parse(event.data);
+                    rebuildAfterServerUpdate(payload);
+                } catch (e) {
+                    console.warn('Не удалось разобрать chat_settings_changed_raw:', e);
+                }
+            });
+            source.onerror = function () {
+            };
+        } catch (e) {
+            console.warn('SSE недоступен:', e);
+        }
+    }
+
     toggleButton.addEventListener('click', () => setDrawerOpen(!drawer.classList.contains('open')));
     closeButton.addEventListener('click', () => setDrawerOpen(false));
 
-    resetButton.addEventListener('click', () => {
-        Object.assign(settings, deepClone(defaults));
-        onChange();
-        refreshControlsFromSettings();
-        setStatus('Сброшено к умолчаниям.', 'ok');
+    revertButton.addEventListener('click', async () => {
+        if (bootstrapFailed) return;
+        const previousLabel = revertButton.textContent;
+        revertButton.disabled = true;
+        revertButton.textContent = '… загрузка';
+        setStatus('Загрузка с сервера…', '');
+        try {
+            const fresh = await loadFromServer();
+            settings = deepClone(fresh);
+            markClean(fresh);
+            refreshControlsFromSettings();
+            applySettings();
+            setStatus('Загружено с сервера.', 'ok');
+        } catch (e) {
+            setStatus('Не удалось загрузить с сервера: ' + (e && e.message ? e.message : e), 'error');
+        } finally {
+            revertButton.disabled = false;
+            revertButton.textContent = previousLabel;
+        }
     });
 
     pushButton.addEventListener('click', async () => {
+        if (bootstrapFailed) return;
         const previousLabel = pushButton.textContent;
         pushButton.disabled = true;
         pushButton.textContent = '… отправка';
@@ -474,6 +556,7 @@
                 setStatus('Ошибка ' + response.status + detail, 'error');
                 return;
             }
+            markClean(settings);
             setStatus('Применено к OBS — оверлей чата обновлён через SSE.', 'ok');
         } catch (e) {
             setStatus('Сеть недоступна или бот не запущен: ' + e.message, 'error');
@@ -483,15 +566,5 @@
         }
     });
 
-    function setStatus(text, kind) {
-        statusEl.textContent = text;
-        statusEl.classList.remove('ok', 'error');
-        if (kind) statusEl.classList.add(kind);
-    }
-
-    populateAnimationSelects();
-    buildColorControls();
-    bindAll();
-    refreshControlsFromSettings();
-    applySettings();
+    bootstrap();
 }());

--- a/PoproshaykaBot.Core/Assets/animations-demo-config.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo-config.js
@@ -1,0 +1,497 @@
+﻿(function () {
+    'use strict';
+
+    const STORAGE_KEY = 'poproshaykabot.demo.chatSettings.v1';
+
+    const defaults = {
+        backgroundColor: { a: 179, r: 0, g: 0, b: 0 },
+        textColor: { a: 255, r: 255, g: 255, b: 255 },
+        usernameColor: { a: 255, r: 145, g: 70, b: 255 },
+        systemMessageColor: { a: 255, r: 255, g: 204, b: 0 },
+        timestampColor: { a: 255, r: 153, g: 153, b: 153 },
+        fontFamily: '"Motiva Sans", "Inter", "Noto Sans", Arial, sans-serif',
+        fontSize: 14,
+        fontBold: false,
+        padding: 5,
+        margin: 5,
+        borderRadius: 5,
+        animationDuration: 300,
+        enableAnimations: true,
+        maxMessages: 50,
+        showTimestamp: true,
+        emoteSizePixels: 28,
+        badgeSizePixels: 18,
+        showUserAvatars: false,
+        userAvatarSizePixels: 32,
+        showUserTypeBorders: true,
+        highlightFirstTimeUsers: true,
+        highlightMentions: true,
+        enableMessageShadows: true,
+        enableSpecialEffects: true,
+        enableSmoothScroll: true,
+        scrollAnimationDuration: 300,
+        autoScrollEnabled: true,
+        scrollToBottomThreshold: 100,
+        scrollPauseAfterUserMs: 3000,
+        userMessageAnimation: 'slide-in-right',
+        botMessageAnimation: 'fade-in-up',
+        systemMessageAnimation: 'fade-in-up',
+        broadcasterMessageAnimation: 'slide-in-left',
+        firstTimeUserMessageAnimation: 'bounce-in',
+        enableMessageFadeOut: true,
+        messageLifetimeSeconds: 30,
+        fadeOutAnimationType: 'fade-out',
+        fadeOutAnimationDurationMs: 1000,
+    };
+
+    const colorFields = [
+        { key: 'backgroundColor', label: 'Фон сообщения' },
+        { key: 'textColor', label: 'Основной текст' },
+        { key: 'usernameColor', label: 'Имя пользователя' },
+        { key: 'systemMessageColor', label: 'Системные' },
+        { key: 'timestampColor', label: 'Время' },
+    ];
+
+    const cssVarMap = {
+        backgroundColor: ['--chat-bg-color', colorToCss],
+        textColor: ['--chat-text-color', colorToCss],
+        usernameColor: ['--chat-username-color', colorToCss],
+        systemMessageColor: ['--chat-system-color', colorToCss],
+        timestampColor: ['--chat-timestamp-color', colorToCss],
+        fontFamily: ['--chat-font-family', v => v],
+        fontSize: ['--chat-font-size', v => v + 'px'],
+        padding: ['--chat-padding', v => v + 'px'],
+        margin: ['--chat-margin', v => v + 'px 0'],
+        borderRadius: ['--chat-border-radius', v => v + 'px'],
+        animationDuration: ['--chat-animation-duration', v => v + 'ms'],
+        emoteSizePixels: ['--emote-size', v => v + 'px'],
+        badgeSizePixels: ['--badge-size', v => v + 'px'],
+        userAvatarSizePixels: ['--avatar-size', v => v + 'px'],
+        fadeOutAnimationDurationMs: ['--fade-out-duration', v => v + 'ms'],
+    };
+
+    const classToggles = [
+        ['showUserTypeBorders', '.message', 'no-borders'],
+        ['highlightFirstTimeUsers', '.message.first-time', 'no-first-time-effects'],
+        ['highlightMentions', '.message', 'no-mentions'],
+        ['enableMessageShadows', '.message', 'no-shadows'],
+        ['enableSpecialEffects', '.message', 'no-special-effects'],
+        ['showTimestamp', '#chat .message, .demo-stage .message', 'no-timestamp'],
+        ['showUserAvatars', '.message', 'no-avatars'],
+    ];
+
+    const fontWeightVar = '--chat-font-weight';
+
+    const entryAnimList = [
+        ['no-animation', 'Без анимации'],
+        ['slide-in-right', 'Скольжение справа'],
+        ['slide-in-left', 'Скольжение слева'],
+        ['fade-in-up', 'Затухание сверху'],
+        ['bounce-in', 'Прыжок'],
+        ['pop-in', 'Поп-ап с упругостью'],
+        ['rubber-band', 'Резиновая лента'],
+        ['tada', 'Та-да!'],
+        ['zoom-blur-in', 'Кинонаезд с размытием'],
+        ['neon-pulse-in', 'Неоновая вспышка'],
+        ['materialize', 'Материализация'],
+        ['glitch-in', 'Глитч'],
+        ['power-up', 'Усиление снизу'],
+        ['slam-in', 'Удар сверху'],
+        ['notification-bell', 'Звон уведомления'],
+        ['hologram', 'Голограмма'],
+        ['flip-in-x', 'Переворот по горизонтали'],
+        ['roll-in', 'Вкатывание'],
+        ['coin-flip', 'Подброс монеты'],
+        ['swoop-in', 'Налёт по диагонали'],
+    ];
+
+    const exitAnimList = [
+        ['no-animation', 'Без анимации'],
+        ['fade-out', 'Исчезновение'],
+        ['slide-out-left', 'Выскользнуть влево'],
+        ['slide-out-right', 'Выскользнуть вправо'],
+        ['scale-down', 'Уменьшение'],
+        ['shrink-up', 'Свернуться вверх'],
+        ['dissolve', 'Растворение в пыль'],
+        ['slide-out-up', 'Выскользнуть вверх'],
+        ['slide-out-down', 'Выскользнуть вниз'],
+        ['rotate-out', 'Поворот с уходом'],
+        ['pixelate-out', 'Пикселизация'],
+    ];
+
+    function deepClone(value) {
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function normalizeColor(raw) {
+        if (!raw) return null;
+        if (typeof raw === 'string') {
+            const hex = raw.startsWith('#') ? raw.slice(1) : raw;
+            if (hex.length === 6) {
+                return {
+                    a: 255,
+                    r: parseInt(hex.slice(0, 2), 16),
+                    g: parseInt(hex.slice(2, 4), 16),
+                    b: parseInt(hex.slice(4, 6), 16),
+                };
+            }
+            if (hex.length === 8) {
+                return {
+                    a: parseInt(hex.slice(0, 2), 16),
+                    r: parseInt(hex.slice(2, 4), 16),
+                    g: parseInt(hex.slice(4, 6), 16),
+                    b: parseInt(hex.slice(6, 8), 16),
+                };
+            }
+            return null;
+        }
+        if (typeof raw === 'object') {
+            const clamp = (v, d) => {
+                const n = Number(v);
+                return Number.isFinite(n) ? Math.max(0, Math.min(255, Math.round(n))) : d;
+            };
+            return {
+                a: clamp(raw.a !== undefined ? raw.a : raw.A, 255),
+                r: clamp(raw.r !== undefined ? raw.r : raw.R, 0),
+                g: clamp(raw.g !== undefined ? raw.g : raw.G, 0),
+                b: clamp(raw.b !== undefined ? raw.b : raw.B, 0),
+            };
+        }
+        return null;
+    }
+
+    function mergeWithDefaults(incoming) {
+        const result = deepClone(defaults);
+        if (!incoming || typeof incoming !== 'object') return result;
+        Object.keys(result).forEach(key => {
+            if (incoming[key] === undefined || incoming[key] === null) return;
+            const def = result[key];
+            if (def && typeof def === 'object' && 'a' in def) {
+                const c = normalizeColor(incoming[key]);
+                if (c) result[key] = c;
+            } else if (typeof def === 'boolean') {
+                result[key] = Boolean(incoming[key]);
+            } else if (typeof def === 'number') {
+                const n = Number(incoming[key]);
+                if (Number.isFinite(n)) result[key] = Math.round(n);
+            } else {
+                result[key] = String(incoming[key]);
+            }
+        });
+        return result;
+    }
+
+    function colorToCss(color) {
+        const a = (color.a / 255).toFixed(3).replace(/\.?0+$/, '') || '0';
+        return 'rgba(' + color.r + ', ' + color.g + ', ' + color.b + ', ' + a + ')';
+    }
+
+    function colorToHex(color) {
+        const hex = n => n.toString(16).padStart(2, '0');
+        return '#' + hex(color.r) + hex(color.g) + hex(color.b);
+    }
+
+    function loadSettings() {
+        try {
+            const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+            if (!raw) return deepClone(defaults);
+            return mergeWithDefaults(JSON.parse(raw));
+        } catch (e) {
+            console.warn('Не удалось прочитать настройки демо из localStorage:', e);
+            return deepClone(defaults);
+        }
+    }
+
+    function saveSettings() {
+        try {
+            globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+        } catch (e) {
+            console.warn('Не удалось сохранить настройки демо в localStorage:', e);
+        }
+    }
+
+    const settings = loadSettings();
+
+    function applySettings() {
+        const root = document.documentElement;
+        Object.keys(cssVarMap).forEach(key => {
+            const entry = cssVarMap[key];
+            root.style.setProperty(entry[0], entry[1](settings[key]));
+        });
+        root.style.setProperty(fontWeightVar, settings.fontBold ? 'bold' : 'normal');
+
+        classToggles.forEach(toggle => {
+            const key = toggle[0];
+            const selector = toggle[1];
+            const className = toggle[2];
+            const enabled = settings[key];
+            document.querySelectorAll(selector).forEach(el => {
+                if (enabled) el.classList.remove(className);
+                else el.classList.add(className);
+            });
+        });
+    }
+
+    const drawer = document.getElementById('config-drawer');
+    const toggleButton = document.getElementById('config-toggle');
+    const closeButton = document.getElementById('config-close');
+    const resetButton = document.getElementById('config-reset');
+    const pushButton = document.getElementById('config-push');
+    const colorsContainer = document.getElementById('config-colors');
+    const statusEl = document.getElementById('config-status');
+
+    function buildColorControls() {
+        colorsContainer.replaceChildren();
+        colorFields.forEach(field => {
+            const key = field.key;
+            const row = document.createElement('div');
+            row.className = 'demo-color-row';
+
+            const labelEl = document.createElement('span');
+            labelEl.textContent = field.label;
+            row.appendChild(labelEl);
+
+            const swatch = document.createElement('span');
+            swatch.className = 'demo-color-swatch';
+            swatch.id = 'cfg-' + key + '-swatch';
+            row.appendChild(swatch);
+
+            const colorInput = document.createElement('input');
+            colorInput.type = 'color';
+            colorInput.id = 'cfg-' + key;
+            colorInput.title = 'Цвет (RGB)';
+            row.appendChild(colorInput);
+
+            const alphaInput = document.createElement('input');
+            alphaInput.type = 'range';
+            alphaInput.id = 'cfg-' + key + '-alpha';
+            alphaInput.min = '0';
+            alphaInput.max = '255';
+            alphaInput.title = 'Прозрачность (alpha)';
+            row.appendChild(alphaInput);
+
+            colorsContainer.appendChild(row);
+
+            const sync = () => {
+                const current = settings[key];
+                const hex = colorToHex(current);
+                if (colorInput.value.toLowerCase() !== hex) colorInput.value = hex;
+                if (alphaInput.value !== String(current.a)) alphaInput.value = String(current.a);
+                swatch.style.setProperty('--swatch-color', colorToCss(current));
+            };
+
+            colorInput.addEventListener('input', () => {
+                const hex = colorInput.value.slice(1);
+                settings[key] = {
+                    a: settings[key].a,
+                    r: parseInt(hex.slice(0, 2), 16),
+                    g: parseInt(hex.slice(2, 4), 16),
+                    b: parseInt(hex.slice(4, 6), 16),
+                };
+                onChange();
+                sync();
+            });
+
+            alphaInput.addEventListener('input', () => {
+                settings[key] = Object.assign({}, settings[key], { a: parseInt(alphaInput.value, 10) });
+                onChange();
+                sync();
+            });
+
+            sync();
+        });
+    }
+
+    function populateAnimationSelects() {
+        document.querySelectorAll('select[data-kind]').forEach(sel => {
+            const list = sel.dataset.kind === 'exit' ? exitAnimList : entryAnimList;
+            sel.replaceChildren();
+            list.forEach(pair => {
+                const opt = document.createElement('option');
+                opt.value = pair[0];
+                opt.textContent = pair[1];
+                sel.appendChild(opt);
+            });
+        });
+    }
+
+    function bindControl(id, settingKey, kind) {
+        const el = document.getElementById(id);
+        if (!el) return;
+
+        if (kind === 'range' || kind === 'number') {
+            if (el.dataset.min !== undefined) el.min = el.dataset.min;
+            if (el.dataset.max !== undefined) el.max = el.dataset.max;
+            if (el.dataset.step !== undefined) el.step = el.dataset.step;
+            el.value = String(settings[settingKey]);
+            const valueLabel = document.getElementById(id + '-value');
+            const suffix = valueLabel ? valueLabel.dataset.suffix || '' : '';
+            const sync = () => {
+                if (valueLabel) valueLabel.textContent = settings[settingKey] + suffix;
+            };
+            sync();
+            el.addEventListener('input', () => {
+                const n = Number(el.value);
+                if (Number.isFinite(n)) {
+                    settings[settingKey] = Math.round(n);
+                    sync();
+                    onChange();
+                }
+            });
+        } else if (kind === 'checkbox') {
+            el.checked = Boolean(settings[settingKey]);
+            el.addEventListener('change', () => {
+                settings[settingKey] = el.checked;
+                onChange();
+            });
+        } else if (kind === 'text') {
+            el.value = String(settings[settingKey]);
+            el.addEventListener('input', () => {
+                settings[settingKey] = el.value;
+                onChange();
+            });
+        } else if (kind === 'select') {
+            el.value = String(settings[settingKey]);
+            el.addEventListener('change', () => {
+                settings[settingKey] = el.value;
+                onChange();
+            });
+        }
+    }
+
+    function bindAll() {
+        bindControl('cfg-fontFamily', 'fontFamily', 'text');
+        bindControl('cfg-fontSize', 'fontSize', 'range');
+        bindControl('cfg-fontBold', 'fontBold', 'checkbox');
+        bindControl('cfg-padding', 'padding', 'range');
+        bindControl('cfg-margin', 'margin', 'range');
+        bindControl('cfg-borderRadius', 'borderRadius', 'range');
+        bindControl('cfg-maxMessages', 'maxMessages', 'range');
+        bindControl('cfg-showTimestamp', 'showTimestamp', 'checkbox');
+        bindControl('cfg-emoteSizePixels', 'emoteSizePixels', 'range');
+        bindControl('cfg-badgeSizePixels', 'badgeSizePixels', 'range');
+        bindControl('cfg-showUserAvatars', 'showUserAvatars', 'checkbox');
+        bindControl('cfg-userAvatarSizePixels', 'userAvatarSizePixels', 'range');
+        bindControl('cfg-showUserTypeBorders', 'showUserTypeBorders', 'checkbox');
+        bindControl('cfg-highlightFirstTimeUsers', 'highlightFirstTimeUsers', 'checkbox');
+        bindControl('cfg-highlightMentions', 'highlightMentions', 'checkbox');
+        bindControl('cfg-enableMessageShadows', 'enableMessageShadows', 'checkbox');
+        bindControl('cfg-enableSpecialEffects', 'enableSpecialEffects', 'checkbox');
+        bindControl('cfg-enableSmoothScroll', 'enableSmoothScroll', 'checkbox');
+        bindControl('cfg-scrollAnimationDuration', 'scrollAnimationDuration', 'range');
+        bindControl('cfg-autoScrollEnabled', 'autoScrollEnabled', 'checkbox');
+        bindControl('cfg-scrollToBottomThreshold', 'scrollToBottomThreshold', 'range');
+        bindControl('cfg-scrollPauseAfterUserMs', 'scrollPauseAfterUserMs', 'range');
+        bindControl('cfg-enableAnimations', 'enableAnimations', 'checkbox');
+        bindControl('cfg-animationDuration', 'animationDuration', 'range');
+        bindControl('cfg-userMessageAnimation', 'userMessageAnimation', 'select');
+        bindControl('cfg-botMessageAnimation', 'botMessageAnimation', 'select');
+        bindControl('cfg-systemMessageAnimation', 'systemMessageAnimation', 'select');
+        bindControl('cfg-broadcasterMessageAnimation', 'broadcasterMessageAnimation', 'select');
+        bindControl('cfg-firstTimeUserMessageAnimation', 'firstTimeUserMessageAnimation', 'select');
+        bindControl('cfg-enableMessageFadeOut', 'enableMessageFadeOut', 'checkbox');
+        bindControl('cfg-messageLifetimeSeconds', 'messageLifetimeSeconds', 'range');
+        bindControl('cfg-fadeOutAnimationType', 'fadeOutAnimationType', 'select');
+        bindControl('cfg-fadeOutAnimationDurationMs', 'fadeOutAnimationDurationMs', 'range');
+    }
+
+    function refreshControlsFromSettings() {
+        Object.keys(settings).forEach(key => {
+            const def = defaults[key];
+            const isColor = def && typeof def === 'object' && 'a' in def;
+            if (isColor) {
+                const colorInput = document.getElementById('cfg-' + key);
+                const alphaInput = document.getElementById('cfg-' + key + '-alpha');
+                const swatch = document.getElementById('cfg-' + key + '-swatch');
+                if (colorInput) colorInput.value = colorToHex(settings[key]);
+                if (alphaInput) alphaInput.value = String(settings[key].a);
+                if (swatch) swatch.style.setProperty('--swatch-color', colorToCss(settings[key]));
+                return;
+            }
+            const el = document.getElementById('cfg-' + key);
+            if (!el) return;
+            if (el.type === 'checkbox') {
+                el.checked = Boolean(settings[key]);
+            } else if (el.type === 'range' || el.type === 'number') {
+                el.value = String(settings[key]);
+                const lbl = document.getElementById(el.id + '-value');
+                if (lbl) lbl.textContent = settings[key] + (lbl.dataset.suffix || '');
+            } else {
+                el.value = String(settings[key]);
+            }
+        });
+    }
+
+    function onChange() {
+        applySettings();
+        saveSettings();
+    }
+
+    function setDrawerOpen(open) {
+        if (open) {
+            drawer.classList.add('open');
+            drawer.setAttribute('aria-hidden', 'false');
+            toggleButton.classList.add('active');
+            toggleButton.setAttribute('aria-pressed', 'true');
+            document.body.classList.add('drawer-open');
+        } else {
+            drawer.classList.remove('open');
+            drawer.setAttribute('aria-hidden', 'true');
+            toggleButton.classList.remove('active');
+            toggleButton.setAttribute('aria-pressed', 'false');
+            document.body.classList.remove('drawer-open');
+        }
+    }
+
+    toggleButton.addEventListener('click', () => setDrawerOpen(!drawer.classList.contains('open')));
+    closeButton.addEventListener('click', () => setDrawerOpen(false));
+
+    resetButton.addEventListener('click', () => {
+        Object.assign(settings, deepClone(defaults));
+        onChange();
+        refreshControlsFromSettings();
+        setStatus('Сброшено к умолчаниям.', 'ok');
+    });
+
+    pushButton.addEventListener('click', async () => {
+        const previousLabel = pushButton.textContent;
+        pushButton.disabled = true;
+        pushButton.textContent = '… отправка';
+        setStatus('Отправка настроек в OBS…', '');
+        try {
+            const response = await fetch('/api/chat-settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(settings),
+            });
+            if (!response.ok) {
+                let detail = '';
+                try {
+                    const err = await response.json();
+                    detail = err && (err.error || err.details) ? ': ' + (err.error || err.details) : '';
+                } catch (_) { /* ignore */
+                }
+                setStatus('Ошибка ' + response.status + detail, 'error');
+                return;
+            }
+            setStatus('Применено к OBS — оверлей чата обновлён через SSE.', 'ok');
+        } catch (e) {
+            setStatus('Сеть недоступна или бот не запущен: ' + e.message, 'error');
+        } finally {
+            pushButton.disabled = false;
+            pushButton.textContent = previousLabel;
+        }
+    });
+
+    function setStatus(text, kind) {
+        statusEl.textContent = text;
+        statusEl.classList.remove('ok', 'error');
+        if (kind) statusEl.classList.add(kind);
+    }
+
+    populateAnimationSelects();
+    buildColorControls();
+    bindAll();
+    refreshControlsFromSettings();
+    applySettings();
+}());

--- a/PoproshaykaBot.Core/Assets/animations-demo-config.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo-config.js
@@ -80,7 +80,7 @@
     }
 
     function colorToCss(color) {
-        const a = (color.a / 255).toFixed(3).replace(/\.?0+$/, '') || '0';
+        const a = String(Number((color.a / 255).toFixed(3)));
         return 'rgba(' + color.r + ', ' + color.g + ', ' + color.b + ', ' + a + ')';
     }
 

--- a/PoproshaykaBot.Core/Assets/animations-demo-config.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo-config.js
@@ -90,7 +90,28 @@
     }
 
     function settingsEqual(a, b) {
-        return JSON.stringify(a) === JSON.stringify(b);
+        if (a === b) return true;
+        if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+            return a === b;
+        }
+        const aArray = Array.isArray(a);
+        const bArray = Array.isArray(b);
+        if (aArray !== bArray) return false;
+        if (aArray) {
+            if (a.length !== b.length) return false;
+            for (let i = 0; i < a.length; i++) {
+                if (!settingsEqual(a[i], b[i])) return false;
+            }
+            return true;
+        }
+        const keysA = Object.keys(a);
+        const keysB = Object.keys(b);
+        if (keysA.length !== keysB.length) return false;
+        for (const key of keysA) {
+            if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+            if (!settingsEqual(a[key], b[key])) return false;
+        }
+        return true;
     }
 
     function readDraftFromStorage() {
@@ -475,6 +496,7 @@
         bindAll();
         refreshControlsFromSettings();
         applySettings();
+        observeStageRebuilds();
         renderDirtyBanner();
         subscribeToSse();
     }
@@ -489,6 +511,16 @@
         refreshControlsFromSettings();
         applySettings();
         setStatus('Настройки обновлены сервером.', 'ok');
+    }
+
+    function observeStageRebuilds() {
+        if (typeof MutationObserver === 'undefined') return;
+        const grids = ['entry-grid', 'exit-grid']
+            .map(id => document.getElementById(id))
+            .filter(grid => grid !== null);
+        if (grids.length === 0) return;
+        const observer = new MutationObserver(() => applySettings());
+        grids.forEach(grid => observer.observe(grid, { childList: true, subtree: true }));
     }
 
     function subscribeToSse() {

--- a/PoproshaykaBot.Core/Assets/animations-demo.css
+++ b/PoproshaykaBot.Core/Assets/animations-demo.css
@@ -1,0 +1,527 @@
+﻿:root {
+    --demo-bg: #0e0e10;
+    --demo-card-bg: #18181b;
+    --demo-card-border: #2a2a2d;
+    --demo-accent: #bf94ff;
+    --demo-accent-strong: #9146ff;
+    --demo-text: #efeff1;
+    --demo-text-muted: #9b9b9d;
+}
+
+html, body {
+    overflow: auto;
+    height: auto;
+    color: var(--demo-text);
+    background: var(--demo-bg);
+    scrollbar-width: thin;
+}
+
+body.demo-body {
+    font-family: "Inter", "Segoe UI", "Noto Sans", Arial, sans-serif;
+    min-height: 100vh;
+    margin: 0;
+    padding: 32px 24px 64px;
+}
+
+.demo-body h1 {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    letter-spacing: -0.5px;
+}
+
+.demo-body header p {
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0 0 28px;
+    color: var(--demo-text-muted);
+}
+
+.demo-body h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 36px 0 16px;
+    padding-bottom: 8px;
+    letter-spacing: 0.3px;
+    border-bottom: 1px solid var(--demo-card-border);
+}
+
+.demo-toolbar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+    padding: 12px 16px;
+    border: 1px solid var(--demo-card-border);
+    border-radius: 8px;
+    background: var(--demo-card-bg);
+    gap: 8px;
+}
+
+.demo-toolbar-label {
+    font-size: 13px;
+    margin-right: 4px;
+    color: var(--demo-text-muted);
+}
+
+.demo-role-button {
+    font-size: 13px;
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    color: var(--demo-text);
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background: transparent;
+}
+
+.demo-role-button:hover {
+    border-color: var(--demo-accent-strong);
+    background: rgba(145, 70, 255, 0.1);
+}
+
+.demo-role-button.active {
+    color: var(--demo-accent);
+    border-color: var(--demo-accent-strong);
+    background: rgba(145, 70, 255, 0.2);
+}
+
+.demo-loop-toggle {
+    margin-left: auto;
+}
+
+.demo-loop-toggle::before {
+    margin-right: 6px;
+    content: "🔁";
+}
+
+.demo-loop-toggle.active::before {
+    content: "✓";
+}
+
+.demo-interval-group {
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+    color: var(--demo-text-muted);
+    gap: 8px;
+}
+
+.demo-interval-group #loop-interval-value {
+    font-weight: 600;
+    min-width: 32px;
+    text-align: right;
+    color: var(--demo-text);
+    font-variant-numeric: tabular-nums;
+}
+
+.demo-interval-slider {
+    width: 110px;
+    cursor: pointer;
+    accent-color: var(--demo-accent-strong);
+}
+
+.demo-play-all {
+    font-size: 13px;
+    font-weight: 600;
+    padding: 6px 14px;
+    cursor: pointer;
+    color: #fff;
+    border: 0;
+    border-radius: 4px;
+    background: var(--demo-accent-strong);
+}
+
+.demo-play-all:hover {
+    background: #7a36e5;
+}
+
+.demo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 16px;
+}
+
+.demo-card {
+    display: flex;
+    flex-direction: column;
+    padding: 14px;
+    transition: border-color 0.2s ease;
+    border: 1px solid var(--demo-card-border);
+    border-radius: 8px;
+    background: var(--demo-card-bg);
+    gap: 10px;
+}
+
+.demo-card:hover {
+    border-color: var(--demo-accent-strong);
+}
+
+.demo-card-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.demo-card-label {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.demo-card-value {
+    font-family: ui-monospace, "JetBrains Mono", Consolas, monospace;
+    font-size: 12px;
+    padding: 2px 8px;
+    cursor: pointer;
+    user-select: all;
+    transition: all 0.15s ease;
+    color: var(--demo-accent);
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: var(--demo-bg);
+}
+
+.demo-card-value:hover {
+    border-color: var(--demo-accent-strong);
+}
+
+.demo-stage {
+    position: relative;
+    display: flex;
+    overflow: hidden;
+    align-items: center;
+    min-height: 64px;
+    padding: 8px;
+    border-radius: 4px;
+    background: var(--demo-bg);
+}
+
+.demo-stage .message {
+    width: 100%;
+    margin: 0;
+}
+
+.copy-notice {
+    font-size: 13px;
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    padding: 8px 18px;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    transform: translateX(-50%);
+    pointer-events: none;
+    opacity: 0;
+    color: #fff;
+    border-radius: 4px;
+    background: var(--demo-accent-strong);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+}
+
+.copy-notice.visible {
+    transform: translateX(-50%) translateY(-4px);
+    opacity: 1;
+}
+
+/* ===== Settings drawer ===== */
+
+body.demo-body.drawer-open {
+    padding-right: 404px;
+}
+
+@media (max-width: 900px) {
+    body.demo-body.drawer-open {
+        padding-right: 24px;
+    }
+}
+
+.demo-config-toggle {
+    font-size: 13px;
+    margin-left: 8px;
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    color: var(--demo-text);
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background: transparent;
+}
+
+.demo-config-toggle:hover,
+.demo-config-toggle.active {
+    color: var(--demo-accent);
+    border-color: var(--demo-accent-strong);
+    background: rgba(145, 70, 255, 0.18);
+}
+
+.demo-config-drawer {
+    position: fixed;
+    z-index: 50;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    width: 380px;
+    transition: transform 0.25s ease;
+    transform: translateX(100%);
+    border-left: 1px solid var(--demo-card-border);
+    background: var(--demo-card-bg);
+    box-shadow: -12px 0 32px rgba(0, 0, 0, 0.45);
+}
+
+.demo-config-drawer.open {
+    transform: translateX(0);
+}
+
+.demo-config-header {
+    display: flex;
+    align-items: center;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--demo-card-border);
+    background: rgba(0, 0, 0, 0.25);
+    gap: 8px;
+}
+
+.demo-config-header h3 {
+    font-size: 15px;
+    font-weight: 600;
+    flex: 1;
+    margin: 0;
+}
+
+.demo-config-close {
+    font-size: 18px;
+    line-height: 1;
+    padding: 4px 8px;
+    cursor: pointer;
+    color: var(--demo-text-muted);
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+}
+
+.demo-config-close:hover {
+    color: var(--demo-text);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.demo-config-actions {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--demo-card-border);
+    background: rgba(0, 0, 0, 0.12);
+    gap: 6px;
+}
+
+.demo-config-actions button {
+    font-size: 12px;
+    padding: 5px 10px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    color: var(--demo-text);
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background: transparent;
+}
+
+.demo-config-actions button:hover {
+    color: var(--demo-accent);
+    border-color: var(--demo-accent-strong);
+}
+
+.demo-config-actions button.primary {
+    color: #fff;
+    border-color: var(--demo-accent-strong);
+    background: var(--demo-accent-strong);
+}
+
+.demo-config-actions button.primary:hover {
+    color: #fff;
+    background: #7a36e5;
+}
+
+.demo-config-body {
+    overflow-y: auto;
+    flex: 1;
+    padding: 12px 16px 24px;
+    scrollbar-width: thin;
+}
+
+.demo-config-body details {
+    overflow: hidden;
+    margin-bottom: 10px;
+    border: 1px solid var(--demo-card-border);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.18);
+}
+
+.demo-config-body details[open] {
+    border-color: rgba(145, 70, 255, 0.4);
+}
+
+.demo-config-body summary {
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 12px;
+    list-style: none;
+    cursor: pointer;
+    user-select: none;
+}
+
+.demo-config-body summary::-webkit-details-marker {
+    display: none;
+}
+
+.demo-config-body summary::before {
+    display: inline-block;
+    margin-right: 4px;
+    content: "▸ ";
+    color: var(--demo-accent);
+}
+
+.demo-config-body details[open] summary::before {
+    content: "▾ ";
+}
+
+.demo-config-section {
+    display: flex;
+    flex-direction: column;
+    padding: 4px 12px 12px;
+    gap: 8px;
+}
+
+.demo-field {
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    color: var(--demo-text-muted);
+    gap: 8px;
+}
+
+.demo-field-label {
+    flex: 1;
+    min-width: 0;
+}
+
+.demo-field-value {
+    font-size: 11px;
+    min-width: 44px;
+    text-align: right;
+    color: var(--demo-text);
+    font-variant-numeric: tabular-nums;
+}
+
+.demo-field input[type="number"],
+.demo-field input[type="text"],
+.demo-field select {
+    font-family: inherit;
+    font-size: 12px;
+    min-width: 0;
+    padding: 4px 6px;
+    color: var(--demo-text);
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background: var(--demo-bg);
+}
+
+.demo-field input[type="range"] {
+    flex: 1;
+    cursor: pointer;
+    accent-color: var(--demo-accent-strong);
+}
+
+.demo-field select {
+    flex: 1;
+}
+
+.demo-field-text input[type="text"] {
+    flex: 1;
+}
+
+.demo-field.demo-field-checkbox {
+    color: var(--demo-text);
+}
+
+.demo-field input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    cursor: pointer;
+    accent-color: var(--demo-accent-strong);
+}
+
+.demo-color-row {
+    font-size: 12px;
+    display: grid;
+    align-items: center;
+    color: var(--demo-text-muted);
+    grid-template-columns: 1fr auto auto auto;
+    gap: 8px;
+}
+
+.demo-color-row input[type="color"] {
+    width: 36px;
+    height: 24px;
+    padding: 0;
+    cursor: pointer;
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background: transparent;
+}
+
+.demo-color-row input[type="range"] {
+    width: 80px;
+    cursor: pointer;
+    accent-color: var(--demo-accent-strong);
+}
+
+.demo-color-swatch {
+    position: relative;
+    overflow: hidden;
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--demo-card-border);
+    border-radius: 4px;
+    background-image: linear-gradient(45deg, #555 25%, transparent 25%),
+    linear-gradient(-45deg, #555 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #555 75%),
+    linear-gradient(-45deg, transparent 75%, #555 75%);
+    background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+    background-size: 8px 8px;
+}
+
+.demo-color-swatch::after {
+    position: absolute;
+    content: "";
+    background: var(--swatch-color, transparent);
+    inset: 0;
+}
+
+.demo-config-hint {
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 4px 0;
+    color: var(--demo-text-muted);
+}
+
+.demo-config-status {
+    font-size: 11px;
+    min-height: 14px;
+    padding: 6px 16px;
+    color: var(--demo-text-muted);
+    border-bottom: 1px solid var(--demo-card-border);
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.demo-config-status:empty {
+    display: none;
+}
+
+.demo-config-status.ok {
+    color: #66d28a;
+}
+
+.demo-config-status.error {
+    color: #ff6b6b;
+}

--- a/PoproshaykaBot.Core/Assets/animations-demo.css
+++ b/PoproshaykaBot.Core/Assets/animations-demo.css
@@ -202,6 +202,15 @@ body.demo-body {
     margin: 0;
 }
 
+.demo-avatar-fallback {
+    font-size: calc(var(--avatar-size, 32px) * 0.45);
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
 .copy-notice {
     font-size: 13px;
     position: fixed;

--- a/PoproshaykaBot.Core/Assets/animations-demo.css
+++ b/PoproshaykaBot.Core/Assets/animations-demo.css
@@ -525,3 +525,40 @@ body.demo-body.drawer-open {
 .demo-config-status.error {
     color: #ff6b6b;
 }
+
+.demo-config-dirty {
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 6px 16px;
+    color: #f5c542;
+    border-bottom: 1px solid var(--demo-card-border);
+    background: rgba(245, 197, 66, 0.08);
+}
+
+.demo-config-dirty[hidden] {
+    display: none;
+}
+
+.demo-config-error {
+    font-size: 12px;
+    line-height: 1.4;
+    padding: 10px 16px;
+    color: #ff6b6b;
+    border-bottom: 1px solid #5a1a1a;
+    background: rgba(255, 107, 107, 0.08);
+}
+
+.demo-config-error[hidden] {
+    display: none;
+}
+
+.demo-empty {
+    font-size: 13px;
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--demo-text-muted);
+    border: 1px dashed var(--demo-card-border);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.18);
+    grid-column: 1 / -1;
+}

--- a/PoproshaykaBot.Core/Assets/animations-demo.html
+++ b/PoproshaykaBot.Core/Assets/animations-demo.html
@@ -101,8 +101,9 @@
             </button>
         </div>
         <div class="demo-config-actions">
-            <button id="config-reset"
-                    type="button">↺ Сбросить
+            <button id="config-revert"
+                    title="Отбросить локальный черновик и подгрузить актуальные настройки с сервера"
+                    type="button">↺ С сервера
             </button>
             <button class="primary"
                     id="config-push"
@@ -113,11 +114,23 @@
         <div aria-live="polite"
              class="demo-config-status"
              id="config-status"></div>
+        <div aria-live="polite"
+             class="demo-config-dirty"
+             hidden
+             id="config-dirty"></div>
+        <div class="demo-config-error"
+             hidden
+             id="config-error"></div>
         <div class="demo-config-body">
 
             <p class="demo-config-hint">
-                Изменения сразу применяются ко всем сообщениям на странице. Кнопка ↑ отправит настройки в OBS через POST
-                <code>/api/chat-settings</code> — живой оверлей обновится через SSE.
+                Источник правды — сервер бота. При загрузке тянутся актуальные значения, диапазоны слайдеров и список
+                анимаций
+                из <code>/api/chat-settings/raw</code>, <code>/api/chat-settings/schema</code> и
+                <code>/api/animations</code>.
+                Локальные правки помечаются как черновик и сохраняются между перезагрузками. Кнопка ↑ POST-ит в
+                <code>/api/chat-settings</code> и приходит обратно через SSE (<code>chat_settings_changed_raw</code>),
+                синхронизируя все открытые вкладки.
             </p>
 
             <details open>
@@ -136,9 +149,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Размер</span>
-                        <input data-max="72"
-                               data-min="8"
-                               id="cfg-fontSize"
+                        <input id="cfg-fontSize"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -158,9 +169,7 @@
                 <div class="demo-config-section">
                     <div class="demo-field">
                         <span class="demo-field-label">Padding</span>
-                        <input data-max="50"
-                               data-min="0"
-                               id="cfg-padding"
+                        <input id="cfg-padding"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -168,9 +177,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Margin</span>
-                        <input data-max="50"
-                               data-min="0"
-                               id="cfg-margin"
+                        <input id="cfg-margin"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -178,9 +185,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Скругление</span>
-                        <input data-max="50"
-                               data-min="0"
-                               id="cfg-borderRadius"
+                        <input id="cfg-borderRadius"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -194,9 +199,7 @@
                 <div class="demo-config-section">
                     <div class="demo-field">
                         <span class="demo-field-label">Максимум сообщений</span>
-                        <input data-max="200"
-                               data-min="10"
-                               id="cfg-maxMessages"
+                        <input id="cfg-maxMessages"
                                type="range">
                         <span class="demo-field-value"
                               id="cfg-maxMessages-value"></span>
@@ -209,9 +212,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Размер эмоутов</span>
-                        <input data-max="128"
-                               data-min="16"
-                               id="cfg-emoteSizePixels"
+                        <input id="cfg-emoteSizePixels"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -219,9 +220,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Размер бейджей</span>
-                        <input data-max="72"
-                               data-min="12"
-                               id="cfg-badgeSizePixels"
+                        <input id="cfg-badgeSizePixels"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -241,9 +240,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Размер аватарки</span>
-                        <input data-max="96"
-                               data-min="16"
-                               id="cfg-userAvatarSizePixels"
+                        <input id="cfg-userAvatarSizePixels"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -299,10 +296,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Длительность скролла</span>
-                        <input data-max="2000"
-                               data-min="0"
-                               data-step="50"
-                               id="cfg-scrollAnimationDuration"
+                        <input id="cfg-scrollAnimationDuration"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="ms"
@@ -316,10 +310,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Порог автоскролла</span>
-                        <input data-max="1000"
-                               data-min="0"
-                               data-step="10"
-                               id="cfg-scrollToBottomThreshold"
+                        <input id="cfg-scrollToBottomThreshold"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="px"
@@ -327,10 +318,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Пауза после ручного скролла</span>
-                        <input data-max="30000"
-                               data-min="0"
-                               data-step="100"
-                               id="cfg-scrollPauseAfterUserMs"
+                        <input id="cfg-scrollPauseAfterUserMs"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="ms"
@@ -350,10 +338,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Длительность</span>
-                        <input data-max="2000"
-                               data-min="100"
-                               data-step="50"
-                               id="cfg-animationDuration"
+                        <input id="cfg-animationDuration"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="ms"
@@ -398,10 +383,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Время жизни</span>
-                        <input data-max="3600"
-                               data-min="1"
-                               data-step="1"
-                               id="cfg-messageLifetimeSeconds"
+                        <input id="cfg-messageLifetimeSeconds"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="s"
@@ -414,10 +396,7 @@
                     </div>
                     <div class="demo-field">
                         <span class="demo-field-label">Длительность ухода</span>
-                        <input data-max="10000"
-                               data-min="100"
-                               data-step="50"
-                               id="cfg-fadeOutAnimationDurationMs"
+                        <input id="cfg-fadeOutAnimationDurationMs"
                                type="range">
                         <span class="demo-field-value"
                               data-suffix="ms"

--- a/PoproshaykaBot.Core/Assets/animations-demo.html
+++ b/PoproshaykaBot.Core/Assets/animations-demo.html
@@ -1,0 +1,698 @@
+﻿<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <title>Демо анимаций - PoproshaykaBot</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="/favicon.ico" rel="icon" type="image/x-icon">
+    <link href="/assets/obs.css" rel="stylesheet">
+    <style>
+        :root {
+            --demo-bg: #0e0e10;
+            --demo-card-bg: #18181b;
+            --demo-card-border: #2a2a2d;
+            --demo-accent: #bf94ff;
+            --demo-accent-strong: #9146ff;
+            --demo-text: #efeff1;
+            --demo-text-muted: #9b9b9d;
+        }
+
+        html, body {
+            background: var(--demo-bg);
+            color: var(--demo-text);
+            height: auto;
+            overflow: auto;
+            scrollbar-width: thin;
+        }
+
+        body.demo-body {
+            font-family: "Inter", "Segoe UI", "Noto Sans", Arial, sans-serif;
+            margin: 0;
+            padding: 32px 24px 64px;
+            min-height: 100vh;
+        }
+
+        .demo-body h1 {
+            font-size: 28px;
+            font-weight: 700;
+            margin: 0 0 8px;
+            letter-spacing: -0.5px;
+        }
+
+        .demo-body header p {
+            color: var(--demo-text-muted);
+            font-size: 14px;
+            margin: 0 0 28px;
+            line-height: 1.5;
+        }
+
+        .demo-body h2 {
+            font-size: 18px;
+            margin: 36px 0 16px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--demo-card-border);
+            font-weight: 600;
+            letter-spacing: 0.3px;
+        }
+
+        .demo-toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            padding: 12px 16px;
+            background: var(--demo-card-bg);
+            border: 1px solid var(--demo-card-border);
+            border-radius: 8px;
+            margin-bottom: 24px;
+        }
+
+        .demo-toolbar-label {
+            font-size: 13px;
+            color: var(--demo-text-muted);
+            margin-right: 4px;
+        }
+
+        .demo-role-button {
+            background: transparent;
+            border: 1px solid var(--demo-card-border);
+            color: var(--demo-text);
+            padding: 6px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 13px;
+            transition: all 0.15s ease;
+        }
+
+        .demo-role-button:hover {
+            border-color: var(--demo-accent-strong);
+            background: rgba(145, 70, 255, 0.1);
+        }
+
+        .demo-role-button.active {
+            border-color: var(--demo-accent-strong);
+            background: rgba(145, 70, 255, 0.2);
+            color: var(--demo-accent);
+        }
+
+        .demo-loop-toggle {
+            margin-left: auto;
+        }
+
+        .demo-loop-toggle::before {
+            content: "🔁";
+            margin-right: 6px;
+        }
+
+        .demo-loop-toggle.active::before {
+            content: "✓";
+        }
+
+        .demo-interval-group {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--demo-text-muted);
+        }
+
+        .demo-interval-group #loop-interval-value {
+            color: var(--demo-text);
+            font-weight: 600;
+            min-width: 32px;
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .demo-interval-slider {
+            width: 110px;
+            accent-color: var(--demo-accent-strong);
+            cursor: pointer;
+        }
+
+        .demo-play-all {
+            background: var(--demo-accent-strong);
+            color: #fff;
+            border: 0;
+            padding: 6px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 600;
+        }
+
+        .demo-play-all:hover {
+            background: #7a36e5;
+        }
+
+        .demo-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 16px;
+        }
+
+        .demo-card {
+            background: var(--demo-card-bg);
+            border: 1px solid var(--demo-card-border);
+            border-radius: 8px;
+            padding: 14px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            transition: border-color 0.2s ease;
+        }
+
+        .demo-card:hover {
+            border-color: var(--demo-accent-strong);
+        }
+
+        .demo-card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+        }
+
+        .demo-card-label {
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        .demo-card-value {
+            background: var(--demo-bg);
+            color: var(--demo-accent);
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-family: ui-monospace, "JetBrains Mono", Consolas, monospace;
+            cursor: pointer;
+            user-select: all;
+            border: 1px solid transparent;
+            transition: all 0.15s ease;
+        }
+
+        .demo-card-value:hover {
+            border-color: var(--demo-accent-strong);
+        }
+
+        .demo-stage {
+            min-height: 64px;
+            background: var(--demo-bg);
+            border-radius: 4px;
+            padding: 8px;
+            display: flex;
+            align-items: center;
+            overflow: hidden;
+            position: relative;
+        }
+
+        .demo-stage .message {
+            width: 100%;
+            margin: 0;
+        }
+
+        .copy-notice {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--demo-accent-strong);
+            color: #fff;
+            padding: 8px 18px;
+            border-radius: 4px;
+            opacity: 0;
+            transition: opacity 0.2s ease, transform 0.2s ease;
+            pointer-events: none;
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+            font-size: 13px;
+        }
+
+        .copy-notice.visible {
+            opacity: 1;
+            transform: translateX(-50%) translateY(-4px);
+        }
+    </style>
+</head>
+<body class="demo-body">
+<header>
+    <h1>Демо анимаций чата</h1>
+    <p>
+        Кликните по карточке, чтобы перезапустить анимацию.
+        Кликните по значению (вроде <code>pop-in</code>) - оно скопируется в буфер обмена.
+        Чтобы сменить роль пользователя на демонстрации, используйте переключатель ниже.
+    </p>
+</header>
+
+<div class="demo-toolbar">
+    <span class="demo-toolbar-label">Роль:</span>
+    <button class="demo-role-button" data-role="" type="button">Пользователь</button>
+    <button class="demo-role-button active" data-role="broadcaster" type="button">Стример</button>
+    <button class="demo-role-button" data-role="moderator" type="button">Модератор</button>
+    <button class="demo-role-button" data-role="vip" type="button">VIP</button>
+    <button class="demo-role-button" data-role="subscriber" type="button">Сабскрайбер</button>
+    <button class="demo-role-button" data-role="first-time" type="button">Новичок</button>
+    <button aria-pressed="false" class="demo-role-button demo-loop-toggle" id="loop-toggle" type="button">Зациклить</button>
+    <span class="demo-interval-group">
+        <label for="loop-interval">Каждые</label>
+        <input class="demo-interval-slider" id="loop-interval" max="10000" min="500" step="250" type="range" value="3500">
+        <span id="loop-interval-value">3.5</span>
+        <span>сек</span>
+    </span>
+    <button class="demo-play-all" id="play-all" type="button">▶ Проиграть всё</button>
+</div>
+
+<section>
+    <h2>Появление (entry)</h2>
+    <div class="demo-grid" id="entry-grid"></div>
+</section>
+
+<section>
+    <h2>Исчезание (exit)</h2>
+    <div class="demo-grid" id="exit-grid"></div>
+</section>
+
+<div aria-live="polite" class="copy-notice" id="copy-notice"></div>
+
+<script>
+(function () {
+    'use strict';
+
+    const entryAnimations = [
+        { value: 'no-animation',     label: 'Без анимации' },
+        { value: 'slide-in-right',   label: 'Скольжение справа' },
+        { value: 'slide-in-left',    label: 'Скольжение слева' },
+        { value: 'fade-in-up',       label: 'Затухание сверху' },
+        { value: 'bounce-in',        label: 'Прыжок' },
+        { value: 'pop-in',           label: 'Поп-ап с упругостью' },
+        { value: 'rubber-band',      label: 'Резиновая лента' },
+        { value: 'tada',             label: 'Та-да!' },
+        { value: 'zoom-blur-in',     label: 'Кинонаезд с размытием' },
+        { value: 'neon-pulse-in',    label: 'Неоновая вспышка' },
+        { value: 'materialize',      label: 'Материализация' },
+        { value: 'glitch-in',        label: 'Глитч' },
+        { value: 'power-up',         label: 'Усиление снизу' },
+        { value: 'slam-in',          label: 'Удар сверху' },
+        { value: 'notification-bell', label: 'Звон уведомления' },
+        { value: 'hologram',         label: 'Голограмма' },
+        { value: 'flip-in-x',        label: 'Переворот по горизонтали' },
+        { value: 'roll-in',          label: 'Вкатывание' },
+        { value: 'coin-flip',        label: 'Подброс монеты' },
+        { value: 'swoop-in',         label: 'Налёт по диагонали' },
+    ];
+
+    const exitAnimations = [
+        { value: 'fade-out',         label: 'Исчезновение' },
+        { value: 'slide-out-left',   label: 'Выскользнуть влево' },
+        { value: 'slide-out-right',  label: 'Выскользнуть вправо' },
+        { value: 'scale-down',       label: 'Уменьшение' },
+        { value: 'shrink-up',        label: 'Свернуться вверх' },
+        { value: 'dissolve',         label: 'Растворение в пыль' },
+        { value: 'slide-out-up',     label: 'Выскользнуть вверх' },
+        { value: 'slide-out-down',   label: 'Выскользнуть вниз' },
+        { value: 'rotate-out',       label: 'Поворот с уходом' },
+        { value: 'pixelate-out',     label: 'Пикселизация' },
+    ];
+
+    const sampleTexts3 = [
+        'Серёга Пират ЖЁСТКО вышел в рейд с одним пистолетом.',
+        'Чат, это не лаги - это Тарков проверяет характер.',
+        'Залутал болт, гайку и минус самооценку.',
+        'План был тихий, но Серёга Пират нажал W.',
+        'Тарков дал, Тарков забрал, Тарков посмеялся.',
+        'Лучший момент стрима: я почти дошёл до выхода.',
+        'Килла посмотрел на меня - я посмотрел на экран загрузки.',
+        'Это не кемпер, это тактический мыслитель в кустах.',
+        'Пошёл за квестом, вернулся с психологической травмой.',
+        'Серёга Пират ЖЁСТКО объяснил, почему броня не нужна.',
+        'Услышал шаги - это были мои надежды на выживание.',
+        'Флешка нашлась ровно после того, как я перестал её искать.',
+        'Вышел на Завод, загрузился обратно в меню.',
+        'Подписался, поставил плюс, забрал страховку.',
+        'Чат, я не умер - я сделал быстрый ребаланс инвентаря.',
+        'Серёга Пират бы сказал: “идём по красоте”, и нажал бы на мину.',
+        'Лут жирный, руки потные, выход где-то в другой вселенной.',
+        'Это просто огонь! Особенно когда граната отскочила обратно.',
+        'Пиратский рейд: зашёл бедным, вышел легендой… в схрон.',
+        'Дикие сегодня добрые: сразу отправляют домой.',
+        'Нашёл выход, но Тарков нашёл меня первым.',
+        'Серёга Пират ЖЁСТКО залутал банку тушёнки и смысл жизни.',
+        'USEC, BEAR, а я просто человек с ножом и мечтой.',
+        'Граната была учебная. Учила смирению.',
+        'Тарков - игра, где даже ящик смотрит на тебя с подозрением.',
+        'Дошёл до экстракта, но экстракт не дошёл до меня.',
+        'Лучший сейв дня: я сохранил спокойствие. Лут - нет.',
+        'Чат, это был не миссплей, это авторский контент.',
+        'Не помер 40 раз на резерве, а схрон разгрузил.',
+    ];
+
+    const sampleTexts = [
+        'мб на выход тогда, велью уже забрали',
+        'поч не мхлр? план же в тупую и работает',
+        'чо ты пикаешь так, тебя любой чвк сотрёт',
+        'не регает, неткод подводит',
+        'держим газ, пока рейд сам себя не закрыл',
+        'зря бегаешь так по карте, ща хуже будет',
+        'у тебя выход под рукой, ес вдруг пригодится',
+        'не велью оделся, не набит квест',
+        'ток не стой афк, до тебя пули и так не долетают',
+        'мб лучше лечь в куст и подумать о жизни',
+        'смысла мало выходить в прицеле, если не знаешь где тип',
+        'пикнул отвратительно, но зато уверенно',
+        'можно через awsd выглянуть и сразу назад, а не принимать судьбу лицом',
+        'зачем ты выходишь на перезарядке?',
+        'угол твой, но голова уже не твоя',
+        'по звуку он справа, по таркову он в душе',
+        'прицел уводит, из-за этого промахиваешься много',
+        'фонарь больше тебя слепит, чем врага',
+        'теплак кал, но идея смешная',
+        'дым + теплак, и можно изображать мыслительный процесс',
+        'какие актуальные задачи на рейд?',
+        'базовый минимум выполнен, смываемся в унитаз',
+        'короткий квест, всего надо потерять нервную систему',
+        'ебаный квест, но пройти всё равно придётся',
+        'сюжетка разблокалась, теперь можно страдать официально',
+        'разгрузка нужна по квестику какому-то',
+        'спавн под квест, значит ща будет не спавн, а цирк',
+        'мб на таможню, проходную зону покемпим?',
+        'на выход сесть и ждать - тоже геймплей',
+        'прост пустой рейд, зато морально стабильный',
+        'стату пули глянь, если интересно',
+        'свд кал, но в руках уверенного человека всё равно кал',
+        'дефолт пристрелка 50 метров, даже калиматор не виноват',
+        'настильность у пули подводит',
+        'все пули летят в прицел, просто прицел живёт отдельно',
+        'мхлр тебе на квест принёс, а ты нос воротишь',
+        'а поч не болт? чисто для страдания',
+        'магазин проверь, а то опять будет театр одного патрона',
+        'сетап найс, только стрелять им кто будет?',
+        'броня есть, уверенности нету',
+        'ты выжал максимум из этого рейда, ты красавчик',
+        'у тебя были все шансы, чуть-чуть не пошло',
+        'а был бы там я',
+        'получай нахуй, ебаная перила',
+        'на нахуй, ебаный камень',
+        'показательная распрыжка, показать что дохуя чо можешь',
+        'и сразу после неё прыгнуть в стену',
+        'прыжок страха или смелости?',
+        'чо ты в пвп забыл',
+        'как тебе лейт пвп таркова?',
+        'держим газ',
+        'WWW держим газ',
+        'киберспортивный расклад пошёл',
+        'велью ноль, зато сдеанонился',
+        'на нахуй, получай рундук',
+        'не натурально роль снайпера отыгрываешь',
+        'мб не терпи, без меня',
+        'чо мне заняться нечем, я негатив пвп не хочу',
+        'в пве можем зайти потестить',
+        'нафик те фигурки, в пве нету престижей',
+        'вот бы радарчик, да. пока кемпим на выходе, айда накодим',
+        'там не баг, там архитектурная боль',
+        'неткод парашный, но звучит как фича',
+        'опять кто-то пересчитывает весь список ради одного токена',
+        'лайфчекер нужен, а не вот это всё',
+        'упёрлось в сеть, поэтому долго конеш работало',
+        'можно было кешировать, но зачем, если можно страдать',
+        'system io moment',
+        'ооп отменяем, переходим на статики, тупа быстрее',
+        'дизайн - на твоих руках',
+        'мб на выход?',
+        'поч не мхлр?',
+        'чо за пик?',
+        'не регает',
+        'держим газ',
+        'нету велью',
+        'пули кал',
+        'теплак кал',
+        'квест душит',
+        'рейд пустой',
+        'чвк не простят',
+        'угол плохой',
+        'зря вышел',
+        'неткод подводит',
+        'пве момент',
+        'пвп негатив',
+        'выход рядом',
+        'сетап странный',
+        'пик отвратительный',
+        'но идея смешная',
+        'запрограммировать шрифт ✔✔✔',
+        'попытаться ✔✔✔',
+        'прыгнуть на месте✔✔✔',
+        'взорвать облако✔✔✔',
+        'дать гранате физику резинового мяча✔✔✔',
+        'захуярить стену✔✔✔',
+        'сохранить паштет✔✔✔',
+        'нахуй паштет✔✔✔',
+        'задымить себе прострел✔✔✔',
+        'прыгнуть от пизды (галочка)',
+        'захуярь землю нахуй (галочка)',
+        'сделать круг вокруг тачки (галочка)',
+        'показательная распрыжка, показать что дохуя чо можешь (галочка)',
+    ];
+
+    let currentRole = 'broadcaster';
+
+    const entryGrid = document.getElementById('entry-grid');
+    const exitGrid = document.getElementById('exit-grid');
+    const copyNotice = document.getElementById('copy-notice');
+
+    const sampleMessages = [
+        ...sampleTexts3.map(function (text) { return { author: 'Серёга Пират', text: text }; }),
+        ...sampleTexts.map(function (text) { return { author: 'qp_illson', text: text }; }),
+    ];
+
+    function pickSampleMessage() {
+        return sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
+    }
+
+    function buildMessage(role) {
+        const pick = pickSampleMessage();
+
+        const div = document.createElement('div');
+        div.className = 'message no-animation';
+
+        if (role === 'first-time') {
+            div.classList.add('first-time');
+        } else if (role) {
+            div.classList.add(role);
+        }
+
+        const content = document.createElement('div');
+        content.className = 'message-content';
+
+        const headerEl = document.createElement('div');
+        headerEl.className = 'message-header';
+
+        const timestamp = document.createElement('time');
+        timestamp.className = 'timestamp';
+        timestamp.textContent = new Date().toLocaleTimeString();
+        headerEl.appendChild(timestamp);
+
+        const username = document.createElement('span');
+        username.className = role && role !== 'first-time'
+            ? `username ${role}`
+            : 'username';
+        username.textContent = pick.author;
+        headerEl.appendChild(username);
+
+        content.appendChild(headerEl);
+
+        const body = document.createElement('div');
+        body.className = 'message-text';
+        body.textContent = pick.text;
+        content.appendChild(body);
+
+        div.appendChild(content);
+        return div;
+    }
+
+    function buildCard(animation, kind) {
+        const card = document.createElement('article');
+        card.className = 'demo-card';
+        card.dataset.kind = kind;
+        card.dataset.animation = animation.value;
+
+        const header = document.createElement('header');
+        header.className = 'demo-card-header';
+
+        const label = document.createElement('span');
+        label.className = 'demo-card-label';
+        label.textContent = animation.label;
+        header.appendChild(label);
+
+        const value = document.createElement('code');
+        value.className = 'demo-card-value';
+        value.textContent = animation.value;
+        value.title = 'Кликните, чтобы скопировать';
+        value.addEventListener('click', function (event) {
+            event.stopPropagation();
+            copyToClipboard(animation.value);
+        });
+        header.appendChild(value);
+
+        card.appendChild(header);
+
+        const stage = document.createElement('div');
+        stage.className = 'demo-stage';
+        stage.appendChild(buildMessage(currentRole));
+        card.appendChild(stage);
+
+        card.addEventListener('click', function () {
+            playCard(card);
+        });
+
+        return card;
+    }
+
+    function playCard(card) {
+        const stage = card.querySelector('.demo-stage');
+        const kind = card.dataset.kind;
+        const animationValue = card.dataset.animation;
+
+        const fresh = buildMessage(currentRole);
+        stage.replaceChildren(fresh);
+
+        void fresh.offsetWidth;
+
+        if (kind === 'entry') {
+            if (animationValue === 'no-animation') {
+                return;
+            }
+            fresh.classList.remove('no-animation');
+            fresh.classList.add(animationValue);
+        } else {
+            fresh.classList.remove('no-animation');
+            requestAnimationFrame(function () {
+                fresh.dataset.exitAnim = animationValue;
+            });
+        }
+    }
+
+    function renderAll() {
+        entryGrid.replaceChildren();
+        for (const animation of entryAnimations) {
+            entryGrid.appendChild(buildCard(animation, 'entry'));
+        }
+
+        exitGrid.replaceChildren();
+        for (const animation of exitAnimations) {
+            exitGrid.appendChild(buildCard(animation, 'exit'));
+        }
+    }
+
+    function playAll() {
+        const cards = document.querySelectorAll('.demo-card');
+        let delay = 0;
+        cards.forEach(function (card) {
+            setTimeout(function () { playCard(card); }, delay);
+            delay += 80;
+        });
+    }
+
+    function copyToClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+                showCopyNotice(text);
+            }).catch(function () {
+                fallbackCopy(text);
+            });
+        } else {
+            fallbackCopy(text);
+        }
+    }
+
+    function fallbackCopy(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            showCopyNotice(text);
+        } catch (e) {
+            console.warn('Не удалось скопировать имя анимации.', e);
+        }
+        document.body.removeChild(textarea);
+    }
+
+    let copyNoticeTimer = null;
+    function showCopyNotice(text) {
+        copyNotice.textContent = 'Скопировано: ' + text;
+        copyNotice.classList.add('visible');
+        if (copyNoticeTimer !== null) {
+            clearTimeout(copyNoticeTimer);
+        }
+        copyNoticeTimer = setTimeout(function () {
+            copyNotice.classList.remove('visible');
+        }, 1600);
+    }
+
+    document.querySelectorAll('.demo-role-button').forEach(function (button) {
+        button.addEventListener('click', function () {
+            currentRole = button.dataset.role || '';
+            document.querySelectorAll('.demo-role-button').forEach(function (other) {
+                other.classList.toggle('active', other === button);
+            });
+            renderAll();
+        });
+    });
+
+    document.getElementById('play-all').addEventListener('click', playAll);
+
+    const loopToggle = document.getElementById('loop-toggle');
+    const loopIntervalSlider = document.getElementById('loop-interval');
+    const loopIntervalValueLabel = document.getElementById('loop-interval-value');
+    let loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
+    let loopTimer = null;
+
+    function formatSeconds(ms) {
+        const seconds = ms / 1000;
+        return ms % 1000 === 0
+            ? seconds.toFixed(0)
+            : seconds.toFixed(1);
+    }
+
+    function setLoopActive(active) {
+        if (active) {
+            if (loopTimer !== null) return;
+            loopToggle.classList.add('active');
+            loopToggle.setAttribute('aria-pressed', 'true');
+            loopToggle.textContent = 'Цикл активен';
+            playAll();
+            loopTimer = setInterval(playAll, loopIntervalMs);
+        } else {
+            if (loopTimer === null) return;
+            clearInterval(loopTimer);
+            loopTimer = null;
+            loopToggle.classList.remove('active');
+            loopToggle.setAttribute('aria-pressed', 'false');
+            loopToggle.textContent = 'Зациклить';
+        }
+    }
+
+    loopToggle.addEventListener('click', function () {
+        setLoopActive(loopTimer === null);
+    });
+
+    loopIntervalSlider.addEventListener('input', function () {
+        loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
+        loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
+        if (loopTimer !== null) {
+            clearInterval(loopTimer);
+            loopTimer = setInterval(playAll, loopIntervalMs);
+        }
+    });
+
+    loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
+
+    renderAll();
+
+    setTimeout(playAll, 400);
+}());
+</script>
+</body>
+</html>

--- a/PoproshaykaBot.Core/Assets/animations-demo.html
+++ b/PoproshaykaBot.Core/Assets/animations-demo.html
@@ -3,696 +3,437 @@
 <head>
     <title>Демо анимаций - PoproshaykaBot</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="/favicon.ico" rel="icon" type="image/x-icon">
-    <link href="/assets/obs.css" rel="stylesheet">
-    <style>
-        :root {
-            --demo-bg: #0e0e10;
-            --demo-card-bg: #18181b;
-            --demo-card-border: #2a2a2d;
-            --demo-accent: #bf94ff;
-            --demo-accent-strong: #9146ff;
-            --demo-text: #efeff1;
-            --demo-text-muted: #9b9b9d;
-        }
-
-        html, body {
-            background: var(--demo-bg);
-            color: var(--demo-text);
-            height: auto;
-            overflow: auto;
-            scrollbar-width: thin;
-        }
-
-        body.demo-body {
-            font-family: "Inter", "Segoe UI", "Noto Sans", Arial, sans-serif;
-            margin: 0;
-            padding: 32px 24px 64px;
-            min-height: 100vh;
-        }
-
-        .demo-body h1 {
-            font-size: 28px;
-            font-weight: 700;
-            margin: 0 0 8px;
-            letter-spacing: -0.5px;
-        }
-
-        .demo-body header p {
-            color: var(--demo-text-muted);
-            font-size: 14px;
-            margin: 0 0 28px;
-            line-height: 1.5;
-        }
-
-        .demo-body h2 {
-            font-size: 18px;
-            margin: 36px 0 16px;
-            padding-bottom: 8px;
-            border-bottom: 1px solid var(--demo-card-border);
-            font-weight: 600;
-            letter-spacing: 0.3px;
-        }
-
-        .demo-toolbar {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-            align-items: center;
-            padding: 12px 16px;
-            background: var(--demo-card-bg);
-            border: 1px solid var(--demo-card-border);
-            border-radius: 8px;
-            margin-bottom: 24px;
-        }
-
-        .demo-toolbar-label {
-            font-size: 13px;
-            color: var(--demo-text-muted);
-            margin-right: 4px;
-        }
-
-        .demo-role-button {
-            background: transparent;
-            border: 1px solid var(--demo-card-border);
-            color: var(--demo-text);
-            padding: 6px 12px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 13px;
-            transition: all 0.15s ease;
-        }
-
-        .demo-role-button:hover {
-            border-color: var(--demo-accent-strong);
-            background: rgba(145, 70, 255, 0.1);
-        }
-
-        .demo-role-button.active {
-            border-color: var(--demo-accent-strong);
-            background: rgba(145, 70, 255, 0.2);
-            color: var(--demo-accent);
-        }
-
-        .demo-loop-toggle {
-            margin-left: auto;
-        }
-
-        .demo-loop-toggle::before {
-            content: "🔁";
-            margin-right: 6px;
-        }
-
-        .demo-loop-toggle.active::before {
-            content: "✓";
-        }
-
-        .demo-interval-group {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 13px;
-            color: var(--demo-text-muted);
-        }
-
-        .demo-interval-group #loop-interval-value {
-            color: var(--demo-text);
-            font-weight: 600;
-            min-width: 32px;
-            text-align: right;
-            font-variant-numeric: tabular-nums;
-        }
-
-        .demo-interval-slider {
-            width: 110px;
-            accent-color: var(--demo-accent-strong);
-            cursor: pointer;
-        }
-
-        .demo-play-all {
-            background: var(--demo-accent-strong);
-            color: #fff;
-            border: 0;
-            padding: 6px 14px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 13px;
-            font-weight: 600;
-        }
-
-        .demo-play-all:hover {
-            background: #7a36e5;
-        }
-
-        .demo-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 16px;
-        }
-
-        .demo-card {
-            background: var(--demo-card-bg);
-            border: 1px solid var(--demo-card-border);
-            border-radius: 8px;
-            padding: 14px;
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-            transition: border-color 0.2s ease;
-        }
-
-        .demo-card:hover {
-            border-color: var(--demo-accent-strong);
-        }
-
-        .demo-card-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: baseline;
-            gap: 12px;
-        }
-
-        .demo-card-label {
-            font-weight: 600;
-            font-size: 14px;
-        }
-
-        .demo-card-value {
-            background: var(--demo-bg);
-            color: var(--demo-accent);
-            padding: 2px 8px;
-            border-radius: 4px;
-            font-size: 12px;
-            font-family: ui-monospace, "JetBrains Mono", Consolas, monospace;
-            cursor: pointer;
-            user-select: all;
-            border: 1px solid transparent;
-            transition: all 0.15s ease;
-        }
-
-        .demo-card-value:hover {
-            border-color: var(--demo-accent-strong);
-        }
-
-        .demo-stage {
-            min-height: 64px;
-            background: var(--demo-bg);
-            border-radius: 4px;
-            padding: 8px;
-            display: flex;
-            align-items: center;
-            overflow: hidden;
-            position: relative;
-        }
-
-        .demo-stage .message {
-            width: 100%;
-            margin: 0;
-        }
-
-        .copy-notice {
-            position: fixed;
-            bottom: 24px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: var(--demo-accent-strong);
-            color: #fff;
-            padding: 8px 18px;
-            border-radius: 4px;
-            opacity: 0;
-            transition: opacity 0.2s ease, transform 0.2s ease;
-            pointer-events: none;
-            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
-            font-size: 13px;
-        }
-
-        .copy-notice.visible {
-            opacity: 1;
-            transform: translateX(-50%) translateY(-4px);
-        }
-    </style>
+    <meta content="width=device-width, initial-scale=1"
+          name="viewport">
+    <link href="/favicon.ico"
+          rel="icon"
+          type="image/x-icon">
+    <link href="/assets/obs.css"
+          rel="stylesheet">
+    <link href="/assets/animations-demo.css"
+          rel="stylesheet">
 </head>
 <body class="demo-body">
-<header>
-    <h1>Демо анимаций чата</h1>
-    <p>
-        Кликните по карточке, чтобы перезапустить анимацию.
-        Кликните по значению (вроде <code>pop-in</code>) - оно скопируется в буфер обмена.
-        Чтобы сменить роль пользователя на демонстрации, используйте переключатель ниже.
-    </p>
-</header>
+    <header>
+        <h1>Демо анимаций чата</h1>
+        <p>
+            Кликните по карточке, чтобы перезапустить анимацию.
+            Кликните по значению (вроде <code>pop-in</code>) - оно скопируется в буфер обмена.
+            Чтобы сменить роль пользователя на демонстрации, используйте переключатель ниже.
+        </p>
+    </header>
 
-<div class="demo-toolbar">
-    <span class="demo-toolbar-label">Роль:</span>
-    <button class="demo-role-button" data-role="" type="button">Пользователь</button>
-    <button class="demo-role-button active" data-role="broadcaster" type="button">Стример</button>
-    <button class="demo-role-button" data-role="moderator" type="button">Модератор</button>
-    <button class="demo-role-button" data-role="vip" type="button">VIP</button>
-    <button class="demo-role-button" data-role="subscriber" type="button">Сабскрайбер</button>
-    <button class="demo-role-button" data-role="first-time" type="button">Новичок</button>
-    <button aria-pressed="false" class="demo-role-button demo-loop-toggle" id="loop-toggle" type="button">Зациклить</button>
-    <span class="demo-interval-group">
+    <div class="demo-toolbar">
+        <span class="demo-toolbar-label">Роль:</span>
+        <button class="demo-role-button"
+                data-role=""
+                type="button">Пользователь
+        </button>
+        <button class="demo-role-button active"
+                data-role="broadcaster"
+                type="button">Стример
+        </button>
+        <button class="demo-role-button"
+                data-role="moderator"
+                type="button">Модератор
+        </button>
+        <button class="demo-role-button"
+                data-role="vip"
+                type="button">VIP
+        </button>
+        <button class="demo-role-button"
+                data-role="subscriber"
+                type="button">Сабскрайбер
+        </button>
+        <button class="demo-role-button"
+                data-role="first-time"
+                type="button">Новичок
+        </button>
+        <button aria-pressed="false"
+                class="demo-role-button demo-loop-toggle"
+                id="loop-toggle"
+                type="button">Зациклить
+        </button>
+        <span class="demo-interval-group">
         <label for="loop-interval">Каждые</label>
-        <input class="demo-interval-slider" id="loop-interval" max="10000" min="500" step="250" type="range" value="3500">
+        <input class="demo-interval-slider"
+               id="loop-interval"
+               max="10000"
+               min="500"
+               step="250"
+               type="range"
+               value="3500">
         <span id="loop-interval-value">3.5</span>
         <span>сек</span>
     </span>
-    <button class="demo-play-all" id="play-all" type="button">▶ Проиграть всё</button>
-</div>
+        <button class="demo-play-all"
+                id="play-all"
+                type="button">▶ Проиграть всё
+        </button>
+        <button aria-pressed="false"
+                class="demo-config-toggle"
+                id="config-toggle"
+                type="button">⚙ Настройки оверлея
+        </button>
+    </div>
 
-<section>
-    <h2>Появление (entry)</h2>
-    <div class="demo-grid" id="entry-grid"></div>
-</section>
+    <section>
+        <h2>Появление (entry)</h2>
+        <div class="demo-grid"
+             id="entry-grid"></div>
+    </section>
 
-<section>
-    <h2>Исчезание (exit)</h2>
-    <div class="demo-grid" id="exit-grid"></div>
-</section>
+    <section>
+        <h2>Исчезание (exit)</h2>
+        <div class="demo-grid"
+             id="exit-grid"></div>
+    </section>
 
-<div aria-live="polite" class="copy-notice" id="copy-notice"></div>
+    <aside aria-hidden="true"
+           class="demo-config-drawer"
+           id="config-drawer">
+        <div class="demo-config-header">
+            <h3>Настройки чат-оверлея</h3>
+            <button aria-label="Закрыть"
+                    class="demo-config-close"
+                    id="config-close"
+                    type="button">✕
+            </button>
+        </div>
+        <div class="demo-config-actions">
+            <button id="config-reset"
+                    type="button">↺ Сбросить
+            </button>
+            <button class="primary"
+                    id="config-push"
+                    title="POST в /api/chat-settings → SSE сразу применит к /chat"
+                    type="button">↑ Применить к OBS
+            </button>
+        </div>
+        <div aria-live="polite"
+             class="demo-config-status"
+             id="config-status"></div>
+        <div class="demo-config-body">
 
-<script>
-(function () {
-    'use strict';
+            <p class="demo-config-hint">
+                Изменения сразу применяются ко всем сообщениям на странице. Кнопка ↑ отправит настройки в OBS через POST
+                <code>/api/chat-settings</code> — живой оверлей обновится через SSE.
+            </p>
 
-    const entryAnimations = [
-        { value: 'no-animation',     label: 'Без анимации' },
-        { value: 'slide-in-right',   label: 'Скольжение справа' },
-        { value: 'slide-in-left',    label: 'Скольжение слева' },
-        { value: 'fade-in-up',       label: 'Затухание сверху' },
-        { value: 'bounce-in',        label: 'Прыжок' },
-        { value: 'pop-in',           label: 'Поп-ап с упругостью' },
-        { value: 'rubber-band',      label: 'Резиновая лента' },
-        { value: 'tada',             label: 'Та-да!' },
-        { value: 'zoom-blur-in',     label: 'Кинонаезд с размытием' },
-        { value: 'neon-pulse-in',    label: 'Неоновая вспышка' },
-        { value: 'materialize',      label: 'Материализация' },
-        { value: 'glitch-in',        label: 'Глитч' },
-        { value: 'power-up',         label: 'Усиление снизу' },
-        { value: 'slam-in',          label: 'Удар сверху' },
-        { value: 'notification-bell', label: 'Звон уведомления' },
-        { value: 'hologram',         label: 'Голограмма' },
-        { value: 'flip-in-x',        label: 'Переворот по горизонтали' },
-        { value: 'roll-in',          label: 'Вкатывание' },
-        { value: 'coin-flip',        label: 'Подброс монеты' },
-        { value: 'swoop-in',         label: 'Налёт по диагонали' },
-    ];
+            <details open>
+                <summary>Цвета</summary>
+                <div class="demo-config-section"
+                     id="config-colors"></div>
+            </details>
 
-    const exitAnimations = [
-        { value: 'fade-out',         label: 'Исчезновение' },
-        { value: 'slide-out-left',   label: 'Выскользнуть влево' },
-        { value: 'slide-out-right',  label: 'Выскользнуть вправо' },
-        { value: 'scale-down',       label: 'Уменьшение' },
-        { value: 'shrink-up',        label: 'Свернуться вверх' },
-        { value: 'dissolve',         label: 'Растворение в пыль' },
-        { value: 'slide-out-up',     label: 'Выскользнуть вверх' },
-        { value: 'slide-out-down',   label: 'Выскользнуть вниз' },
-        { value: 'rotate-out',       label: 'Поворот с уходом' },
-        { value: 'pixelate-out',     label: 'Пикселизация' },
-    ];
+            <details open>
+                <summary>Шрифт</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-text">
+                        <span class="demo-field-label">Семейство</span>
+                        <input id="cfg-fontFamily"
+                               type="text">
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Размер</span>
+                        <input data-max="72"
+                               data-min="8"
+                               id="cfg-fontSize"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-fontSize-value"></span>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-fontBold"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-fontBold">Жирный шрифт</label>
+                    </div>
+                </div>
+            </details>
 
-    const sampleTexts3 = [
-        'Серёга Пират ЖЁСТКО вышел в рейд с одним пистолетом.',
-        'Чат, это не лаги - это Тарков проверяет характер.',
-        'Залутал болт, гайку и минус самооценку.',
-        'План был тихий, но Серёга Пират нажал W.',
-        'Тарков дал, Тарков забрал, Тарков посмеялся.',
-        'Лучший момент стрима: я почти дошёл до выхода.',
-        'Килла посмотрел на меня - я посмотрел на экран загрузки.',
-        'Это не кемпер, это тактический мыслитель в кустах.',
-        'Пошёл за квестом, вернулся с психологической травмой.',
-        'Серёга Пират ЖЁСТКО объяснил, почему броня не нужна.',
-        'Услышал шаги - это были мои надежды на выживание.',
-        'Флешка нашлась ровно после того, как я перестал её искать.',
-        'Вышел на Завод, загрузился обратно в меню.',
-        'Подписался, поставил плюс, забрал страховку.',
-        'Чат, я не умер - я сделал быстрый ребаланс инвентаря.',
-        'Серёга Пират бы сказал: “идём по красоте”, и нажал бы на мину.',
-        'Лут жирный, руки потные, выход где-то в другой вселенной.',
-        'Это просто огонь! Особенно когда граната отскочила обратно.',
-        'Пиратский рейд: зашёл бедным, вышел легендой… в схрон.',
-        'Дикие сегодня добрые: сразу отправляют домой.',
-        'Нашёл выход, но Тарков нашёл меня первым.',
-        'Серёга Пират ЖЁСТКО залутал банку тушёнки и смысл жизни.',
-        'USEC, BEAR, а я просто человек с ножом и мечтой.',
-        'Граната была учебная. Учила смирению.',
-        'Тарков - игра, где даже ящик смотрит на тебя с подозрением.',
-        'Дошёл до экстракта, но экстракт не дошёл до меня.',
-        'Лучший сейв дня: я сохранил спокойствие. Лут - нет.',
-        'Чат, это был не миссплей, это авторский контент.',
-        'Не помер 40 раз на резерве, а схрон разгрузил.',
-    ];
+            <details>
+                <summary>Геометрия</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field">
+                        <span class="demo-field-label">Padding</span>
+                        <input data-max="50"
+                               data-min="0"
+                               id="cfg-padding"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-padding-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Margin</span>
+                        <input data-max="50"
+                               data-min="0"
+                               id="cfg-margin"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-margin-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Скругление</span>
+                        <input data-max="50"
+                               data-min="0"
+                               id="cfg-borderRadius"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-borderRadius-value"></span>
+                    </div>
+                </div>
+            </details>
 
-    const sampleTexts = [
-        'мб на выход тогда, велью уже забрали',
-        'поч не мхлр? план же в тупую и работает',
-        'чо ты пикаешь так, тебя любой чвк сотрёт',
-        'не регает, неткод подводит',
-        'держим газ, пока рейд сам себя не закрыл',
-        'зря бегаешь так по карте, ща хуже будет',
-        'у тебя выход под рукой, ес вдруг пригодится',
-        'не велью оделся, не набит квест',
-        'ток не стой афк, до тебя пули и так не долетают',
-        'мб лучше лечь в куст и подумать о жизни',
-        'смысла мало выходить в прицеле, если не знаешь где тип',
-        'пикнул отвратительно, но зато уверенно',
-        'можно через awsd выглянуть и сразу назад, а не принимать судьбу лицом',
-        'зачем ты выходишь на перезарядке?',
-        'угол твой, но голова уже не твоя',
-        'по звуку он справа, по таркову он в душе',
-        'прицел уводит, из-за этого промахиваешься много',
-        'фонарь больше тебя слепит, чем врага',
-        'теплак кал, но идея смешная',
-        'дым + теплак, и можно изображать мыслительный процесс',
-        'какие актуальные задачи на рейд?',
-        'базовый минимум выполнен, смываемся в унитаз',
-        'короткий квест, всего надо потерять нервную систему',
-        'ебаный квест, но пройти всё равно придётся',
-        'сюжетка разблокалась, теперь можно страдать официально',
-        'разгрузка нужна по квестику какому-то',
-        'спавн под квест, значит ща будет не спавн, а цирк',
-        'мб на таможню, проходную зону покемпим?',
-        'на выход сесть и ждать - тоже геймплей',
-        'прост пустой рейд, зато морально стабильный',
-        'стату пули глянь, если интересно',
-        'свд кал, но в руках уверенного человека всё равно кал',
-        'дефолт пристрелка 50 метров, даже калиматор не виноват',
-        'настильность у пули подводит',
-        'все пули летят в прицел, просто прицел живёт отдельно',
-        'мхлр тебе на квест принёс, а ты нос воротишь',
-        'а поч не болт? чисто для страдания',
-        'магазин проверь, а то опять будет театр одного патрона',
-        'сетап найс, только стрелять им кто будет?',
-        'броня есть, уверенности нету',
-        'ты выжал максимум из этого рейда, ты красавчик',
-        'у тебя были все шансы, чуть-чуть не пошло',
-        'а был бы там я',
-        'получай нахуй, ебаная перила',
-        'на нахуй, ебаный камень',
-        'показательная распрыжка, показать что дохуя чо можешь',
-        'и сразу после неё прыгнуть в стену',
-        'прыжок страха или смелости?',
-        'чо ты в пвп забыл',
-        'как тебе лейт пвп таркова?',
-        'держим газ',
-        'WWW держим газ',
-        'киберспортивный расклад пошёл',
-        'велью ноль, зато сдеанонился',
-        'на нахуй, получай рундук',
-        'не натурально роль снайпера отыгрываешь',
-        'мб не терпи, без меня',
-        'чо мне заняться нечем, я негатив пвп не хочу',
-        'в пве можем зайти потестить',
-        'нафик те фигурки, в пве нету престижей',
-        'вот бы радарчик, да. пока кемпим на выходе, айда накодим',
-        'там не баг, там архитектурная боль',
-        'неткод парашный, но звучит как фича',
-        'опять кто-то пересчитывает весь список ради одного токена',
-        'лайфчекер нужен, а не вот это всё',
-        'упёрлось в сеть, поэтому долго конеш работало',
-        'можно было кешировать, но зачем, если можно страдать',
-        'system io moment',
-        'ооп отменяем, переходим на статики, тупа быстрее',
-        'дизайн - на твоих руках',
-        'мб на выход?',
-        'поч не мхлр?',
-        'чо за пик?',
-        'не регает',
-        'держим газ',
-        'нету велью',
-        'пули кал',
-        'теплак кал',
-        'квест душит',
-        'рейд пустой',
-        'чвк не простят',
-        'угол плохой',
-        'зря вышел',
-        'неткод подводит',
-        'пве момент',
-        'пвп негатив',
-        'выход рядом',
-        'сетап странный',
-        'пик отвратительный',
-        'но идея смешная',
-        'запрограммировать шрифт ✔✔✔',
-        'попытаться ✔✔✔',
-        'прыгнуть на месте✔✔✔',
-        'взорвать облако✔✔✔',
-        'дать гранате физику резинового мяча✔✔✔',
-        'захуярить стену✔✔✔',
-        'сохранить паштет✔✔✔',
-        'нахуй паштет✔✔✔',
-        'задымить себе прострел✔✔✔',
-        'прыгнуть от пизды (галочка)',
-        'захуярь землю нахуй (галочка)',
-        'сделать круг вокруг тачки (галочка)',
-        'показательная распрыжка, показать что дохуя чо можешь (галочка)',
-    ];
+            <details>
+                <summary>Сообщения</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field">
+                        <span class="demo-field-label">Максимум сообщений</span>
+                        <input data-max="200"
+                               data-min="10"
+                               id="cfg-maxMessages"
+                               type="range">
+                        <span class="demo-field-value"
+                              id="cfg-maxMessages-value"></span>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-showTimestamp"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-showTimestamp">Показывать время</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Размер эмоутов</span>
+                        <input data-max="128"
+                               data-min="16"
+                               id="cfg-emoteSizePixels"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-emoteSizePixels-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Размер бейджей</span>
+                        <input data-max="72"
+                               data-min="12"
+                               id="cfg-badgeSizePixels"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-badgeSizePixels-value"></span>
+                    </div>
+                </div>
+            </details>
 
-    let currentRole = 'broadcaster';
+            <details>
+                <summary>Аватарки</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-showUserAvatars"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-showUserAvatars">Показывать аватарки</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Размер аватарки</span>
+                        <input data-max="96"
+                               data-min="16"
+                               id="cfg-userAvatarSizePixels"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-userAvatarSizePixels-value"></span>
+                    </div>
+                </div>
+            </details>
 
-    const entryGrid = document.getElementById('entry-grid');
-    const exitGrid = document.getElementById('exit-grid');
-    const copyNotice = document.getElementById('copy-notice');
+            <details>
+                <summary>Поведение и эффекты</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-showUserTypeBorders"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-showUserTypeBorders">Цветные рамки по ролям</label>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-highlightFirstTimeUsers"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-highlightFirstTimeUsers">Подсвечивать новичков</label>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-highlightMentions"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-highlightMentions">Подсвечивать упоминания</label>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-enableMessageShadows"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-enableMessageShadows">Тени сообщений</label>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-enableSpecialEffects"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-enableSpecialEffects">Специальные эффекты</label>
+                    </div>
+                </div>
+            </details>
 
-    const sampleMessages = [
-        ...sampleTexts3.map(function (text) { return { author: 'Серёга Пират', text: text }; }),
-        ...sampleTexts.map(function (text) { return { author: 'qp_illson', text: text }; }),
-    ];
+            <details>
+                <summary>Скролл</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-enableSmoothScroll"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-enableSmoothScroll">Плавный скролл</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Длительность скролла</span>
+                        <input data-max="2000"
+                               data-min="0"
+                               data-step="50"
+                               id="cfg-scrollAnimationDuration"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="ms"
+                              id="cfg-scrollAnimationDuration-value"></span>
+                    </div>
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-autoScrollEnabled"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-autoScrollEnabled">Автоскролл</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Порог автоскролла</span>
+                        <input data-max="1000"
+                               data-min="0"
+                               data-step="10"
+                               id="cfg-scrollToBottomThreshold"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="px"
+                              id="cfg-scrollToBottomThreshold-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Пауза после ручного скролла</span>
+                        <input data-max="30000"
+                               data-min="0"
+                               data-step="100"
+                               id="cfg-scrollPauseAfterUserMs"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="ms"
+                              id="cfg-scrollPauseAfterUserMs-value"></span>
+                    </div>
+                </div>
+            </details>
 
-    function pickSampleMessage() {
-        return sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
-    }
+            <details open>
+                <summary>Анимации появления</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-enableAnimations"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-enableAnimations">Включить анимации</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Длительность</span>
+                        <input data-max="2000"
+                               data-min="100"
+                               data-step="50"
+                               id="cfg-animationDuration"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="ms"
+                              id="cfg-animationDuration-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Пользователь</span>
+                        <select data-kind="entry"
+                                id="cfg-userMessageAnimation"></select>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Бот</span>
+                        <select data-kind="entry"
+                                id="cfg-botMessageAnimation"></select>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Системное</span>
+                        <select data-kind="entry"
+                                id="cfg-systemMessageAnimation"></select>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Стример</span>
+                        <select data-kind="entry"
+                                id="cfg-broadcasterMessageAnimation"></select>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Новичок</span>
+                        <select data-kind="entry"
+                                id="cfg-firstTimeUserMessageAnimation"></select>
+                    </div>
+                </div>
+            </details>
 
-    function buildMessage(role) {
-        const pick = pickSampleMessage();
+            <details>
+                <summary>Затухание</summary>
+                <div class="demo-config-section">
+                    <div class="demo-field demo-field-checkbox">
+                        <input id="cfg-enableMessageFadeOut"
+                               type="checkbox">
+                        <label class="demo-field-label"
+                               for="cfg-enableMessageFadeOut">Затухание сообщений</label>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Время жизни</span>
+                        <input data-max="3600"
+                               data-min="1"
+                               data-step="1"
+                               id="cfg-messageLifetimeSeconds"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="s"
+                              id="cfg-messageLifetimeSeconds-value"></span>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Анимация ухода</span>
+                        <select data-kind="exit"
+                                id="cfg-fadeOutAnimationType"></select>
+                    </div>
+                    <div class="demo-field">
+                        <span class="demo-field-label">Длительность ухода</span>
+                        <input data-max="10000"
+                               data-min="100"
+                               data-step="50"
+                               id="cfg-fadeOutAnimationDurationMs"
+                               type="range">
+                        <span class="demo-field-value"
+                              data-suffix="ms"
+                              id="cfg-fadeOutAnimationDurationMs-value"></span>
+                    </div>
+                </div>
+            </details>
 
-        const div = document.createElement('div');
-        div.className = 'message no-animation';
+        </div>
+    </aside>
 
-        if (role === 'first-time') {
-            div.classList.add('first-time');
-        } else if (role) {
-            div.classList.add(role);
-        }
+    <div aria-live="polite"
+         class="copy-notice"
+         id="copy-notice"></div>
 
-        const content = document.createElement('div');
-        content.className = 'message-content';
-
-        const headerEl = document.createElement('div');
-        headerEl.className = 'message-header';
-
-        const timestamp = document.createElement('time');
-        timestamp.className = 'timestamp';
-        timestamp.textContent = new Date().toLocaleTimeString();
-        headerEl.appendChild(timestamp);
-
-        const username = document.createElement('span');
-        username.className = role && role !== 'first-time'
-            ? `username ${role}`
-            : 'username';
-        username.textContent = pick.author;
-        headerEl.appendChild(username);
-
-        content.appendChild(headerEl);
-
-        const body = document.createElement('div');
-        body.className = 'message-text';
-        body.textContent = pick.text;
-        content.appendChild(body);
-
-        div.appendChild(content);
-        return div;
-    }
-
-    function buildCard(animation, kind) {
-        const card = document.createElement('article');
-        card.className = 'demo-card';
-        card.dataset.kind = kind;
-        card.dataset.animation = animation.value;
-
-        const header = document.createElement('header');
-        header.className = 'demo-card-header';
-
-        const label = document.createElement('span');
-        label.className = 'demo-card-label';
-        label.textContent = animation.label;
-        header.appendChild(label);
-
-        const value = document.createElement('code');
-        value.className = 'demo-card-value';
-        value.textContent = animation.value;
-        value.title = 'Кликните, чтобы скопировать';
-        value.addEventListener('click', function (event) {
-            event.stopPropagation();
-            copyToClipboard(animation.value);
-        });
-        header.appendChild(value);
-
-        card.appendChild(header);
-
-        const stage = document.createElement('div');
-        stage.className = 'demo-stage';
-        stage.appendChild(buildMessage(currentRole));
-        card.appendChild(stage);
-
-        card.addEventListener('click', function () {
-            playCard(card);
-        });
-
-        return card;
-    }
-
-    function playCard(card) {
-        const stage = card.querySelector('.demo-stage');
-        const kind = card.dataset.kind;
-        const animationValue = card.dataset.animation;
-
-        const fresh = buildMessage(currentRole);
-        stage.replaceChildren(fresh);
-
-        void fresh.offsetWidth;
-
-        if (kind === 'entry') {
-            if (animationValue === 'no-animation') {
-                return;
-            }
-            fresh.classList.remove('no-animation');
-            fresh.classList.add(animationValue);
-        } else {
-            fresh.classList.remove('no-animation');
-            requestAnimationFrame(function () {
-                fresh.dataset.exitAnim = animationValue;
-            });
-        }
-    }
-
-    function renderAll() {
-        entryGrid.replaceChildren();
-        for (const animation of entryAnimations) {
-            entryGrid.appendChild(buildCard(animation, 'entry'));
-        }
-
-        exitGrid.replaceChildren();
-        for (const animation of exitAnimations) {
-            exitGrid.appendChild(buildCard(animation, 'exit'));
-        }
-    }
-
-    function playAll() {
-        const cards = document.querySelectorAll('.demo-card');
-        let delay = 0;
-        cards.forEach(function (card) {
-            setTimeout(function () { playCard(card); }, delay);
-            delay += 80;
-        });
-    }
-
-    function copyToClipboard(text) {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(text).then(function () {
-                showCopyNotice(text);
-            }).catch(function () {
-                fallbackCopy(text);
-            });
-        } else {
-            fallbackCopy(text);
-        }
-    }
-
-    function fallbackCopy(text) {
-        const textarea = document.createElement('textarea');
-        textarea.value = text;
-        textarea.setAttribute('readonly', '');
-        textarea.style.position = 'absolute';
-        textarea.style.left = '-9999px';
-        document.body.appendChild(textarea);
-        textarea.select();
-        try {
-            document.execCommand('copy');
-            showCopyNotice(text);
-        } catch (e) {
-            console.warn('Не удалось скопировать имя анимации.', e);
-        }
-        document.body.removeChild(textarea);
-    }
-
-    let copyNoticeTimer = null;
-    function showCopyNotice(text) {
-        copyNotice.textContent = 'Скопировано: ' + text;
-        copyNotice.classList.add('visible');
-        if (copyNoticeTimer !== null) {
-            clearTimeout(copyNoticeTimer);
-        }
-        copyNoticeTimer = setTimeout(function () {
-            copyNotice.classList.remove('visible');
-        }, 1600);
-    }
-
-    document.querySelectorAll('.demo-role-button').forEach(function (button) {
-        button.addEventListener('click', function () {
-            currentRole = button.dataset.role || '';
-            document.querySelectorAll('.demo-role-button').forEach(function (other) {
-                other.classList.toggle('active', other === button);
-            });
-            renderAll();
-        });
-    });
-
-    document.getElementById('play-all').addEventListener('click', playAll);
-
-    const loopToggle = document.getElementById('loop-toggle');
-    const loopIntervalSlider = document.getElementById('loop-interval');
-    const loopIntervalValueLabel = document.getElementById('loop-interval-value');
-    let loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
-    let loopTimer = null;
-
-    function formatSeconds(ms) {
-        const seconds = ms / 1000;
-        return ms % 1000 === 0
-            ? seconds.toFixed(0)
-            : seconds.toFixed(1);
-    }
-
-    function setLoopActive(active) {
-        if (active) {
-            if (loopTimer !== null) return;
-            loopToggle.classList.add('active');
-            loopToggle.setAttribute('aria-pressed', 'true');
-            loopToggle.textContent = 'Цикл активен';
-            playAll();
-            loopTimer = setInterval(playAll, loopIntervalMs);
-        } else {
-            if (loopTimer === null) return;
-            clearInterval(loopTimer);
-            loopTimer = null;
-            loopToggle.classList.remove('active');
-            loopToggle.setAttribute('aria-pressed', 'false');
-            loopToggle.textContent = 'Зациклить';
-        }
-    }
-
-    loopToggle.addEventListener('click', function () {
-        setLoopActive(loopTimer === null);
-    });
-
-    loopIntervalSlider.addEventListener('input', function () {
-        loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
-        loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
-        if (loopTimer !== null) {
-            clearInterval(loopTimer);
-            loopTimer = setInterval(playAll, loopIntervalMs);
-        }
-    });
-
-    loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
-
-    renderAll();
-
-    setTimeout(playAll, 400);
-}());
-</script>
+    <script src="/assets/animations-demo.js"></script>
+    <script src="/assets/animations-demo-config.js"></script>
 </body>
 </html>

--- a/PoproshaykaBot.Core/Assets/animations-demo.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo.js
@@ -214,14 +214,8 @@
 
     function buildFakeAvatar(author) {
         const span = document.createElement('span');
-        span.className = 'avatar avatar-loaded';
+        span.className = 'avatar avatar-loaded demo-avatar-fallback';
         span.style.background = 'hsl(' + hashCodeToHue(author) + ', 55%, 45%)';
-        span.style.color = '#fff';
-        span.style.display = 'inline-flex';
-        span.style.alignItems = 'center';
-        span.style.justifyContent = 'center';
-        span.style.fontWeight = '700';
-        span.style.fontSize = 'calc(var(--avatar-size, 32px) * 0.45)';
         span.textContent = (author || '?').trim().charAt(0).toUpperCase();
 
         const login = displayNameToLogin[author];

--- a/PoproshaykaBot.Core/Assets/animations-demo.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo.js
@@ -158,7 +158,9 @@
     ];
 
     function pickSampleMessage() {
-        return sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
+        const buffer = new Uint32Array(1);
+        crypto.getRandomValues(buffer);
+        return sampleMessages[buffer[0] % sampleMessages.length];
     }
 
     function hashCodeToHue(text) {

--- a/PoproshaykaBot.Core/Assets/animations-demo.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo.js
@@ -1,41 +1,8 @@
 ﻿(function () {
     'use strict';
 
-    const entryAnimations = [
-        { value: 'no-animation', label: 'Без анимации' },
-        { value: 'slide-in-right', label: 'Скольжение справа' },
-        { value: 'slide-in-left', label: 'Скольжение слева' },
-        { value: 'fade-in-up', label: 'Затухание сверху' },
-        { value: 'bounce-in', label: 'Прыжок' },
-        { value: 'pop-in', label: 'Поп-ап с упругостью' },
-        { value: 'rubber-band', label: 'Резиновая лента' },
-        { value: 'tada', label: 'Та-да!' },
-        { value: 'zoom-blur-in', label: 'Кинонаезд с размытием' },
-        { value: 'neon-pulse-in', label: 'Неоновая вспышка' },
-        { value: 'materialize', label: 'Материализация' },
-        { value: 'glitch-in', label: 'Глитч' },
-        { value: 'power-up', label: 'Усиление снизу' },
-        { value: 'slam-in', label: 'Удар сверху' },
-        { value: 'notification-bell', label: 'Звон уведомления' },
-        { value: 'hologram', label: 'Голограмма' },
-        { value: 'flip-in-x', label: 'Переворот по горизонтали' },
-        { value: 'roll-in', label: 'Вкатывание' },
-        { value: 'coin-flip', label: 'Подброс монеты' },
-        { value: 'swoop-in', label: 'Налёт по диагонали' },
-    ];
-
-    const exitAnimations = [
-        { value: 'fade-out', label: 'Исчезновение' },
-        { value: 'slide-out-left', label: 'Выскользнуть влево' },
-        { value: 'slide-out-right', label: 'Выскользнуть вправо' },
-        { value: 'scale-down', label: 'Уменьшение' },
-        { value: 'shrink-up', label: 'Свернуться вверх' },
-        { value: 'dissolve', label: 'Растворение в пыль' },
-        { value: 'slide-out-up', label: 'Выскользнуть вверх' },
-        { value: 'slide-out-down', label: 'Выскользнуть вниз' },
-        { value: 'rotate-out', label: 'Поворот с уходом' },
-        { value: 'pixelate-out', label: 'Пикселизация' },
-    ];
+    let entryAnimations = [];
+    let exitAnimations = [];
 
     const sampleTexts3 = [
         'Серёга Пират ЖЁСТКО вышел в рейд с одним пистолетом.',
@@ -500,7 +467,30 @@
 
     loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
 
-    renderAll();
+    function renderError(message) {
+        const stub = function () {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'demo-empty';
+            wrapper.textContent = message;
+            return wrapper;
+        };
+        entryGrid.replaceChildren(stub());
+        exitGrid.replaceChildren(stub());
+    }
 
-    setTimeout(playAll, 400);
+    fetch('/api/animations')
+        .then(response => {
+            if (!response.ok) throw new Error('HTTP ' + response.status);
+            return response.json();
+        })
+        .then(payload => {
+            entryAnimations = payload.entry || [];
+            exitAnimations = (payload.exit || []).filter(opt => opt.value !== 'no-animation');
+            renderAll();
+            setTimeout(playAll, 400);
+        })
+        .catch(error => {
+            console.error('Не удалось загрузить /api/animations:', error);
+            renderError('Не удалось загрузить список анимаций с сервера: ' + (error && error.message ? error.message : error));
+        });
 }());

--- a/PoproshaykaBot.Core/Assets/animations-demo.js
+++ b/PoproshaykaBot.Core/Assets/animations-demo.js
@@ -1,0 +1,506 @@
+﻿(function () {
+    'use strict';
+
+    const entryAnimations = [
+        { value: 'no-animation', label: 'Без анимации' },
+        { value: 'slide-in-right', label: 'Скольжение справа' },
+        { value: 'slide-in-left', label: 'Скольжение слева' },
+        { value: 'fade-in-up', label: 'Затухание сверху' },
+        { value: 'bounce-in', label: 'Прыжок' },
+        { value: 'pop-in', label: 'Поп-ап с упругостью' },
+        { value: 'rubber-band', label: 'Резиновая лента' },
+        { value: 'tada', label: 'Та-да!' },
+        { value: 'zoom-blur-in', label: 'Кинонаезд с размытием' },
+        { value: 'neon-pulse-in', label: 'Неоновая вспышка' },
+        { value: 'materialize', label: 'Материализация' },
+        { value: 'glitch-in', label: 'Глитч' },
+        { value: 'power-up', label: 'Усиление снизу' },
+        { value: 'slam-in', label: 'Удар сверху' },
+        { value: 'notification-bell', label: 'Звон уведомления' },
+        { value: 'hologram', label: 'Голограмма' },
+        { value: 'flip-in-x', label: 'Переворот по горизонтали' },
+        { value: 'roll-in', label: 'Вкатывание' },
+        { value: 'coin-flip', label: 'Подброс монеты' },
+        { value: 'swoop-in', label: 'Налёт по диагонали' },
+    ];
+
+    const exitAnimations = [
+        { value: 'fade-out', label: 'Исчезновение' },
+        { value: 'slide-out-left', label: 'Выскользнуть влево' },
+        { value: 'slide-out-right', label: 'Выскользнуть вправо' },
+        { value: 'scale-down', label: 'Уменьшение' },
+        { value: 'shrink-up', label: 'Свернуться вверх' },
+        { value: 'dissolve', label: 'Растворение в пыль' },
+        { value: 'slide-out-up', label: 'Выскользнуть вверх' },
+        { value: 'slide-out-down', label: 'Выскользнуть вниз' },
+        { value: 'rotate-out', label: 'Поворот с уходом' },
+        { value: 'pixelate-out', label: 'Пикселизация' },
+    ];
+
+    const sampleTexts3 = [
+        'Серёга Пират ЖЁСТКО вышел в рейд с одним пистолетом.',
+        'Чат, это не лаги - это Тарков проверяет характер.',
+        'Залутал болт, гайку и минус самооценку.',
+        'План был тихий, но Серёга Пират нажал W.',
+        'Тарков дал, Тарков забрал, Тарков посмеялся.',
+        'Лучший момент стрима: я почти дошёл до выхода.',
+        'Килла посмотрел на меня - я посмотрел на экран загрузки.',
+        'Это не кемпер, это тактический мыслитель в кустах.',
+        'Пошёл за квестом, вернулся с психологической травмой.',
+        'Серёга Пират ЖЁСТКО объяснил, почему броня не нужна.',
+        'Услышал шаги - это были мои надежды на выживание.',
+        'Флешка нашлась ровно после того, как я перестал её искать.',
+        'Вышел на Завод, загрузился обратно в меню.',
+        'Подписался, поставил плюс, забрал страховку.',
+        'Чат, я не умер - я сделал быстрый ребаланс инвентаря.',
+        'Серёга Пират бы сказал: “идём по красоте”, и нажал бы на мину.',
+        'Лут жирный, руки потные, выход где-то в другой вселенной.',
+        'Это просто огонь! Особенно когда граната отскочила обратно.',
+        'Пиратский рейд: зашёл бедным, вышел легендой… в схрон.',
+        'Дикие сегодня добрые: сразу отправляют домой.',
+        'Нашёл выход, но Тарков нашёл меня первым.',
+        'Серёга Пират ЖЁСТКО залутал банку тушёнки и смысл жизни.',
+        'USEC, BEAR, а я просто человек с ножом и мечтой.',
+        'Граната была учебная. Учила смирению.',
+        'Тарков - игра, где даже ящик смотрит на тебя с подозрением.',
+        'Дошёл до экстракта, но экстракт не дошёл до меня.',
+        'Лучший сейв дня: я сохранил спокойствие. Лут - нет.',
+        'Чат, это был не миссплей, это авторский контент.',
+        'Не помер 40 раз на резерве, а схрон разгрузил.',
+    ];
+
+    const sampleTexts = [
+        'мб на выход тогда, велью уже забрали',
+        'поч не мхлр? план же в тупую и работает',
+        'чо ты пикаешь так, тебя любой чвк сотрёт',
+        'не регает, неткод подводит',
+        'держим газ, пока рейд сам себя не закрыл',
+        'зря бегаешь так по карте, ща хуже будет',
+        'у тебя выход под рукой, ес вдруг пригодится',
+        'не велью оделся, не набит квест',
+        'ток не стой афк, до тебя пули и так не долетают',
+        'мб лучше лечь в куст и подумать о жизни',
+        'смысла мало выходить в прицеле, если не знаешь где тип',
+        'пикнул отвратительно, но зато уверенно',
+        'можно через awsd выглянуть и сразу назад, а не принимать судьбу лицом',
+        'зачем ты выходишь на перезарядке?',
+        'угол твой, но голова уже не твоя',
+        'по звуку он справа, по таркову он в душе',
+        'прицел уводит, из-за этого промахиваешься много',
+        'фонарь больше тебя слепит, чем врага',
+        'теплак кал, но идея смешная',
+        'дым + теплак, и можно изображать мыслительный процесс',
+        'какие актуальные задачи на рейд?',
+        'базовый минимум выполнен, смываемся в унитаз',
+        'короткий квест, всего надо потерять нервную систему',
+        'ебаный квест, но пройти всё равно придётся',
+        'сюжетка разблокалась, теперь можно страдать официально',
+        'разгрузка нужна по квестику какому-то',
+        'спавн под квест, значит ща будет не спавн, а цирк',
+        'мб на таможню, проходную зону покемпим?',
+        'на выход сесть и ждать - тоже геймплей',
+        'прост пустой рейд, зато морально стабильный',
+        'стату пули глянь, если интересно',
+        'свд кал, но в руках уверенного человека всё равно кал',
+        'дефолт пристрелка 50 метров, даже калиматор не виноват',
+        'настильность у пули подводит',
+        'все пули летят в прицел, просто прицел живёт отдельно',
+        'мхлр тебе на квест принёс, а ты нос воротишь',
+        'а поч не болт? чисто для страдания',
+        'магазин проверь, а то опять будет театр одного патрона',
+        'сетап найс, только стрелять им кто будет?',
+        'броня есть, уверенности нету',
+        'ты выжал максимум из этого рейда, ты красавчик',
+        'у тебя были все шансы, чуть-чуть не пошло',
+        'а был бы там я',
+        'получай нахуй, ебаная перила',
+        'на нахуй, ебаный камень',
+        'показательная распрыжка, показать что дохуя чо можешь',
+        'и сразу после неё прыгнуть в стену',
+        'прыжок страха или смелости?',
+        'чо ты в пвп забыл',
+        'как тебе лейт пвп таркова?',
+        'держим газ',
+        'WWW держим газ',
+        'киберспортивный расклад пошёл',
+        'велью ноль, зато сдеанонился',
+        'на нахуй, получай рундук',
+        'не натурально роль снайпера отыгрываешь',
+        'мб не терпи, без меня',
+        'чо мне заняться нечем, я негатив пвп не хочу',
+        'в пве можем зайти потестить',
+        'нафик те фигурки, в пве нету престижей',
+        'вот бы радарчик, да. пока кемпим на выходе, айда накодим',
+        'там не баг, там архитектурная боль',
+        'неткод парашный, но звучит как фича',
+        'опять кто-то пересчитывает весь список ради одного токена',
+        'лайфчекер нужен, а не вот это всё',
+        'упёрлось в сеть, поэтому долго конеш работало',
+        'можно было кешировать, но зачем, если можно страдать',
+        'system io moment',
+        'ооп отменяем, переходим на статики, тупа быстрее',
+        'дизайн - на твоих руках',
+        'мб на выход?',
+        'поч не мхлр?',
+        'чо за пик?',
+        'не регает',
+        'держим газ',
+        'нету велью',
+        'пули кал',
+        'теплак кал',
+        'квест душит',
+        'рейд пустой',
+        'чвк не простят',
+        'угол плохой',
+        'зря вышел',
+        'неткод подводит',
+        'пве момент',
+        'пвп негатив',
+        'выход рядом',
+        'сетап странный',
+        'пик отвратительный',
+        'но идея смешная',
+        'запрограммировать шрифт ✔✔✔',
+        'попытаться ✔✔✔',
+        'прыгнуть на месте✔✔✔',
+        'взорвать облако✔✔✔',
+        'дать гранате физику резинового мяча✔✔✔',
+        'захуярить стену✔✔✔',
+        'сохранить паштет✔✔✔',
+        'нахуй паштет✔✔✔',
+        'задымить себе прострел✔✔✔',
+        'прыгнуть от пизды (галочка)',
+        'захуярь землю нахуй (галочка)',
+        'сделать круг вокруг тачки (галочка)',
+        'показательная распрыжка, показать что дохуя чо можешь (галочка)',
+    ];
+
+    let currentRole = 'broadcaster';
+
+    const entryGrid = document.getElementById('entry-grid');
+    const exitGrid = document.getElementById('exit-grid');
+    const copyNotice = document.getElementById('copy-notice');
+
+    const sampleMessages = [
+        ...sampleTexts3.map(function (text) {
+            return { author: 'Серёга Пират', text };
+        }),
+        ...sampleTexts.map(function (text) {
+            return { author: 'qp_illson', text };
+        }),
+    ];
+
+    function pickSampleMessage() {
+        return sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
+    }
+
+    function hashCodeToHue(text) {
+        let hash = 0;
+        for (let i = 0; i < text.length; i++) {
+            hash = hash * 31 + text.charCodeAt(i) | 0;
+        }
+        return Math.abs(hash) % 360;
+    }
+
+    const displayNameToLogin = {
+        'qp_illson': 'qp_illson',
+        'Серёга Пират': 'serega_pirat',
+    };
+
+    const avatarUrlCache = new Map();
+    const pendingAvatarTargets = new Map();
+
+    function applyAvatarImage(span, url) {
+        const safe = String(url).replace(/"/g, '\\"');
+        span.style.backgroundImage = 'url("' + safe + '")';
+        span.style.backgroundSize = 'cover';
+        span.style.backgroundPosition = 'center';
+        span.style.color = 'transparent';
+    }
+
+    function ensureAvatarFetched(login) {
+        if (avatarUrlCache.has(login)) {
+            return;
+        }
+        avatarUrlCache.set(login, null);
+        fetch('/api/user-avatar?login=' + encodeURIComponent(login))
+            .then(function (response) {
+                return response.ok ? response.json() : null;
+            })
+            .then(function (payload) {
+                return payload && payload.url ? payload.url : null;
+            })
+            .catch(function () {
+                return null;
+            })
+            .then(function (url) {
+                avatarUrlCache.set(login, url || null);
+                if (!url) return;
+                const waiting = pendingAvatarTargets.get(login);
+                if (!waiting) return;
+                pendingAvatarTargets.delete(login);
+                waiting.forEach(function (span) {
+                    applyAvatarImage(span, url);
+                });
+            });
+    }
+
+    function buildFakeAvatar(author) {
+        const span = document.createElement('span');
+        span.className = 'avatar avatar-loaded';
+        span.style.background = 'hsl(' + hashCodeToHue(author) + ', 55%, 45%)';
+        span.style.color = '#fff';
+        span.style.display = 'inline-flex';
+        span.style.alignItems = 'center';
+        span.style.justifyContent = 'center';
+        span.style.fontWeight = '700';
+        span.style.fontSize = 'calc(var(--avatar-size, 32px) * 0.45)';
+        span.textContent = (author || '?').trim().charAt(0).toUpperCase();
+
+        const login = displayNameToLogin[author];
+        if (login) {
+            const cached = avatarUrlCache.get(login);
+            if (typeof cached === 'string' && cached) {
+                applyAvatarImage(span, cached);
+            } else {
+                if (!pendingAvatarTargets.has(login)) pendingAvatarTargets.set(login, []);
+                pendingAvatarTargets.get(login).push(span);
+                ensureAvatarFetched(login);
+            }
+        }
+
+        return span;
+    }
+
+    function buildMessage(role) {
+        const pick = pickSampleMessage();
+
+        const div = document.createElement('div');
+        div.className = 'message no-animation';
+
+        if (role === 'first-time') {
+            div.classList.add('first-time');
+        } else if (role) {
+            div.classList.add(role);
+        }
+
+        div.appendChild(buildFakeAvatar(pick.author));
+
+        const content = document.createElement('div');
+        content.className = 'message-content';
+
+        const headerEl = document.createElement('div');
+        headerEl.className = 'message-header';
+
+        const timestamp = document.createElement('time');
+        timestamp.className = 'timestamp';
+        timestamp.textContent = new Date().toLocaleTimeString();
+        headerEl.appendChild(timestamp);
+
+        const username = document.createElement('span');
+        username.className = role && role !== 'first-time'
+            ? `username ${role}`
+            : 'username';
+        username.textContent = pick.author;
+        headerEl.appendChild(username);
+
+        content.appendChild(headerEl);
+
+        const body = document.createElement('div');
+        body.className = 'message-text';
+        body.textContent = pick.text;
+        content.appendChild(body);
+
+        div.appendChild(content);
+        return div;
+    }
+
+    function buildCard(animation, kind) {
+        const card = document.createElement('article');
+        card.className = 'demo-card';
+        card.dataset.kind = kind;
+        card.dataset.animation = animation.value;
+
+        const header = document.createElement('header');
+        header.className = 'demo-card-header';
+
+        const label = document.createElement('span');
+        label.className = 'demo-card-label';
+        label.textContent = animation.label;
+        header.appendChild(label);
+
+        const value = document.createElement('code');
+        value.className = 'demo-card-value';
+        value.textContent = animation.value;
+        value.title = 'Кликните, чтобы скопировать';
+        value.addEventListener('click', function (event) {
+            event.stopPropagation();
+            copyToClipboard(animation.value);
+        });
+        header.appendChild(value);
+
+        card.appendChild(header);
+
+        const stage = document.createElement('div');
+        stage.className = 'demo-stage';
+        stage.appendChild(buildMessage(currentRole));
+        card.appendChild(stage);
+
+        card.addEventListener('click', function () {
+            playCard(card);
+        });
+
+        return card;
+    }
+
+    function playCard(card) {
+        const stage = card.querySelector('.demo-stage');
+        const kind = card.dataset.kind;
+        const animationValue = card.dataset.animation;
+
+        const fresh = buildMessage(currentRole);
+        stage.replaceChildren(fresh);
+
+        void fresh.offsetWidth;
+
+        if (kind === 'entry') {
+            if (animationValue === 'no-animation') {
+                return;
+            }
+            fresh.classList.remove('no-animation');
+            fresh.classList.add(animationValue);
+        } else {
+            fresh.classList.remove('no-animation');
+            requestAnimationFrame(function () {
+                fresh.dataset.exitAnim = animationValue;
+            });
+        }
+    }
+
+    function renderAll() {
+        entryGrid.replaceChildren();
+        for (const animation of entryAnimations) {
+            entryGrid.appendChild(buildCard(animation, 'entry'));
+        }
+
+        exitGrid.replaceChildren();
+        for (const animation of exitAnimations) {
+            exitGrid.appendChild(buildCard(animation, 'exit'));
+        }
+    }
+
+    function playAll() {
+        const cards = document.querySelectorAll('.demo-card');
+        let delay = 0;
+        cards.forEach(function (card) {
+            setTimeout(function () {
+                playCard(card);
+            }, delay);
+            delay += 80;
+        });
+    }
+
+    function copyToClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+                showCopyNotice(text);
+            }).catch(function () {
+                fallbackCopy(text);
+            });
+        } else {
+            fallbackCopy(text);
+        }
+    }
+
+    function fallbackCopy(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            showCopyNotice(text);
+        } catch (e) {
+            console.warn('Не удалось скопировать имя анимации.', e);
+        }
+        document.body.removeChild(textarea);
+    }
+
+    let copyNoticeTimer = null;
+
+    function showCopyNotice(text) {
+        copyNotice.textContent = 'Скопировано: ' + text;
+        copyNotice.classList.add('visible');
+        if (copyNoticeTimer !== null) {
+            clearTimeout(copyNoticeTimer);
+        }
+        copyNoticeTimer = setTimeout(function () {
+            copyNotice.classList.remove('visible');
+        }, 1600);
+    }
+
+    document.querySelectorAll('.demo-role-button').forEach(function (button) {
+        button.addEventListener('click', function () {
+            currentRole = button.dataset.role || '';
+            document.querySelectorAll('.demo-role-button').forEach(function (other) {
+                other.classList.toggle('active', other === button);
+            });
+            renderAll();
+        });
+    });
+
+    document.getElementById('play-all').addEventListener('click', playAll);
+
+    const loopToggle = document.getElementById('loop-toggle');
+    const loopIntervalSlider = document.getElementById('loop-interval');
+    const loopIntervalValueLabel = document.getElementById('loop-interval-value');
+    let loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
+    let loopTimer = null;
+
+    function formatSeconds(ms) {
+        const seconds = ms / 1000;
+        return ms % 1000 === 0
+            ? seconds.toFixed(0)
+            : seconds.toFixed(1);
+    }
+
+    function setLoopActive(active) {
+        if (active) {
+            if (loopTimer !== null) return;
+            loopToggle.classList.add('active');
+            loopToggle.setAttribute('aria-pressed', 'true');
+            loopToggle.textContent = 'Цикл активен';
+            playAll();
+            loopTimer = setInterval(playAll, loopIntervalMs);
+        } else {
+            if (loopTimer === null) return;
+            clearInterval(loopTimer);
+            loopTimer = null;
+            loopToggle.classList.remove('active');
+            loopToggle.setAttribute('aria-pressed', 'false');
+            loopToggle.textContent = 'Зациклить';
+        }
+    }
+
+    loopToggle.addEventListener('click', function () {
+        setLoopActive(loopTimer === null);
+    });
+
+    loopIntervalSlider.addEventListener('input', function () {
+        loopIntervalMs = parseInt(loopIntervalSlider.value, 10);
+        loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
+        if (loopTimer !== null) {
+            clearInterval(loopTimer);
+            loopTimer = setInterval(playAll, loopIntervalMs);
+        }
+    });
+
+    loopIntervalValueLabel.textContent = formatSeconds(loopIntervalMs);
+
+    renderAll();
+
+    setTimeout(playAll, 400);
+}());

--- a/PoproshaykaBot.Core/Assets/obs.css
+++ b/PoproshaykaBot.Core/Assets/obs.css
@@ -231,6 +231,115 @@ body::-webkit-scrollbar {
     }
 }
 
+/* === Juicy entry animations === */
+
+@keyframes popIn {
+    0%   { transform: scale(0.3) rotate(-5deg); opacity: 0; }
+    60%  { transform: scale(1.1) rotate(2deg);  opacity: 1; }
+    80%  { transform: scale(0.95) rotate(-1deg); }
+    100% { transform: scale(1) rotate(0);       opacity: 1; }
+}
+
+@keyframes rubberBand {
+    0%   { transform: scale(1); opacity: 0; }
+    30%  { transform: scaleX(1.25) scaleY(0.75); opacity: 1; }
+    40%  { transform: scaleX(0.75) scaleY(1.25); }
+    50%  { transform: scaleX(1.15) scaleY(0.85); }
+    65%  { transform: scaleX(0.95) scaleY(1.05); }
+    75%  { transform: scaleX(1.05) scaleY(0.95); }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes tada {
+    0%   { transform: scale(0.9) rotate(0deg); opacity: 0; }
+    10%, 20% { transform: scale(0.9) rotate(-3deg); opacity: 1; }
+    30%, 50%, 70%, 90% { transform: scale(1.1) rotate(3deg); }
+    40%, 60%, 80% { transform: scale(1.1) rotate(-3deg); }
+    100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+
+@keyframes zoomBlurIn {
+    0%   { transform: scale(1.4); filter: blur(12px); opacity: 0; }
+    60%  { transform: scale(1.05); filter: blur(2px); opacity: 1; }
+    100% { transform: scale(1); filter: blur(0); opacity: 1; }
+}
+
+@keyframes neonPulseIn {
+    0%   { transform: translateX(20px); opacity: 0; box-shadow: var(--shadow-small), 0 0 0 rgba(145, 70, 255, 0); }
+    50%  { transform: translateX(-4px); opacity: 1; box-shadow: var(--shadow-small), 0 0 24px rgba(145, 70, 255, 0.85); }
+    100% { transform: translateX(0); opacity: 1; box-shadow: var(--shadow-small), 0 0 8px rgba(145, 70, 255, 0.3); }
+}
+
+@keyframes materialize {
+    0%   { opacity: 0; filter: blur(20px); transform: scale(0.95); }
+    60%  { opacity: 1; filter: blur(4px); }
+    100% { opacity: 1; filter: blur(0); transform: scale(1); }
+}
+
+@keyframes glitchIn {
+    0%   { transform: translate(0); opacity: 0; }
+    10%  { transform: translate(-3px, 2px); opacity: 1; text-shadow: 2px 0 #ff0080, -2px 0 #00ffff; }
+    20%  { transform: translate(3px, -2px); text-shadow: -2px 0 #ff0080, 2px 0 #00ffff; }
+    30%  { transform: translate(-2px, 1px); text-shadow: 1px 0 #ff0080, -1px 0 #00ffff; }
+    45%  { transform: translate(2px, -1px); text-shadow: -1px 0 #ff0080, 1px 0 #00ffff; }
+    60%  { transform: translate(-1px, 0); text-shadow: none; }
+    100% { transform: translate(0); opacity: 1; text-shadow: var(--text-shadow); }
+}
+
+@keyframes powerUp {
+    0%   { transform: translateY(30px) scaleY(0.3); opacity: 0; box-shadow: var(--shadow-small), 0 0 0 rgba(81, 207, 102, 0); }
+    50%  { transform: translateY(8px) scaleY(1.05); opacity: 1; box-shadow: var(--shadow-small), 0 -8px 24px rgba(81, 207, 102, 0.6); }
+    100% { transform: translateY(0) scaleY(1); opacity: 1; box-shadow: var(--shadow-small), 0 0 8px rgba(81, 207, 102, 0.3); }
+}
+
+@keyframes slamIn {
+    0%   { transform: translateY(-60px) scale(1.3); opacity: 0; filter: blur(4px); }
+    40%  { transform: translateY(8px) scale(0.95); opacity: 1; filter: blur(0); }
+    55%  { transform: translateY(-6px) scale(1.03); }
+    70%  { transform: translateY(3px) scale(0.98); }
+    85%  { transform: translateY(-1px) scale(1.01); }
+    100% { transform: translateY(0) scale(1); }
+}
+
+@keyframes notificationBell {
+    0%   { transform: rotate(0); opacity: 0; }
+    20%  { transform: rotate(-6deg); opacity: 1; }
+    40%  { transform: rotate(5deg); }
+    60%  { transform: rotate(-3deg); }
+    80%  { transform: rotate(2deg); }
+    100% { transform: rotate(0); opacity: 1; }
+}
+
+@keyframes hologram {
+    0%   { transform: translateY(12px); opacity: 0; filter: brightness(2) saturate(2); }
+    35%  { transform: translateY(0); opacity: 0.85; filter: brightness(1.3) saturate(1.5); }
+    100% { transform: translateY(0); opacity: 1; filter: brightness(1) saturate(1); }
+}
+
+@keyframes flipInX {
+    0%   { transform: perspective(420px) rotateX(90deg); opacity: 0; }
+    50%  { transform: perspective(420px) rotateX(-15deg); opacity: 1; }
+    75%  { transform: perspective(420px) rotateX(8deg); }
+    100% { transform: perspective(420px) rotateX(0); opacity: 1; }
+}
+
+@keyframes rollIn {
+    0%   { transform: translateX(-100%) rotate(-120deg); opacity: 0; }
+    100% { transform: translateX(0) rotate(0); opacity: 1; }
+}
+
+@keyframes coinFlip {
+    0%   { transform: perspective(600px) rotateY(0) scale(0.85); opacity: 0; }
+    50%  { transform: perspective(600px) rotateY(180deg) scale(0.7); opacity: 1; }
+    100% { transform: perspective(600px) rotateY(360deg) scale(1); opacity: 1; }
+}
+
+@keyframes swoopIn {
+    0%   { transform: translate(40px, 20px) skewX(-12deg); opacity: 0; }
+    60%  { transform: translate(-6px, -3px) skewX(3deg); opacity: 1; }
+    100% { transform: translate(0, 0) skewX(0); opacity: 1; }
+}
+
 @keyframes pulse {
     0%, 100% {
         box-shadow: var(--shadow-small), 0 0 10px rgba(255, 107, 107, 0.3);
@@ -265,6 +374,82 @@ body::-webkit-scrollbar {
 
 .message.bounce-in {
     animation: bounceIn var(--chat-animation-duration) ease-out;
+}
+
+.message.pop-in {
+    transform-origin: left center;
+    animation: popIn calc(var(--chat-animation-duration) * 1.6) cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.message.rubber-band {
+    transform-origin: left center;
+    animation: rubberBand calc(var(--chat-animation-duration) * 1.8) ease-out both;
+}
+
+.message.tada {
+    transform-origin: left center;
+    animation: tada calc(var(--chat-animation-duration) * 2.4) ease-out both;
+}
+
+.message.zoom-blur-in {
+    will-change: transform, opacity, filter;
+    animation: zoomBlurIn calc(var(--chat-animation-duration) * 1.4) ease-out both;
+}
+
+.message.neon-pulse-in {
+    will-change: transform, opacity, box-shadow;
+    animation: neonPulseIn calc(var(--chat-animation-duration) * 1.6) ease-out both;
+}
+
+.message.materialize {
+    will-change: opacity, filter, transform;
+    animation: materialize calc(var(--chat-animation-duration) * 1.5) ease-out both;
+}
+
+.message.glitch-in {
+    will-change: transform, opacity;
+    animation: glitchIn calc(var(--chat-animation-duration) * 1.6) steps(8, end) both;
+}
+
+.message.power-up {
+    transform-origin: bottom center;
+    will-change: transform, opacity, box-shadow;
+    animation: powerUp calc(var(--chat-animation-duration) * 1.4) cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.message.slam-in {
+    will-change: transform, opacity, filter;
+    animation: slamIn calc(var(--chat-animation-duration) * 1.8) cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.message.notification-bell {
+    transform-origin: top center;
+    animation: notificationBell calc(var(--chat-animation-duration) * 1.5) ease-out both;
+}
+
+.message.hologram {
+    will-change: opacity, filter, transform;
+    animation: hologram calc(var(--chat-animation-duration) * 1.6) ease-out both;
+}
+
+.message.flip-in-x {
+    transform-origin: center top;
+    backface-visibility: hidden;
+    animation: flipInX calc(var(--chat-animation-duration) * 1.5) ease-out both;
+}
+
+.message.roll-in {
+    transform-origin: left center;
+    animation: rollIn calc(var(--chat-animation-duration) * 1.4) ease-out both;
+}
+
+.message.coin-flip {
+    backface-visibility: hidden;
+    animation: coinFlip calc(var(--chat-animation-duration) * 1.8) ease-in-out both;
+}
+
+.message.swoop-in {
+    animation: swoopIn calc(var(--chat-animation-duration) * 1.3) cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .username {
@@ -509,6 +694,96 @@ body::-webkit-scrollbar {
     }
 }
 
+@keyframes dissolve {
+    0% {
+        opacity: 1;
+        filter: blur(0) brightness(1);
+        max-height: 100px;
+        margin: var(--chat-margin);
+        padding: var(--chat-padding);
+    }
+    100% {
+        opacity: 0;
+        filter: blur(12px) brightness(1.3);
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+}
+
+@keyframes slideOutUp {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+        max-height: 100px;
+        margin: var(--chat-margin);
+        padding: var(--chat-padding);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-100%);
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+}
+
+@keyframes slideOutDown {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+        max-height: 100px;
+        margin: var(--chat-margin);
+        padding: var(--chat-padding);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(80%);
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+}
+
+@keyframes rotateOut {
+    0% {
+        opacity: 1;
+        transform: rotate(0) scale(1);
+        max-height: 100px;
+        margin: var(--chat-margin);
+        padding: var(--chat-padding);
+    }
+    100% {
+        opacity: 0;
+        transform: rotate(60deg) scale(0.4);
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+}
+
+@keyframes pixelateOut {
+    0% {
+        opacity: 1;
+        filter: contrast(1) blur(0);
+        max-height: 100px;
+        margin: var(--chat-margin);
+        padding: var(--chat-padding);
+    }
+    100% {
+        opacity: 0;
+        filter: contrast(4) blur(6px);
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+}
+
 .message[data-exit-anim="fade-out"] {
     animation: fadeOutMessage var(--fade-out-duration) ease-out forwards !important;
 }
@@ -527,6 +802,26 @@ body::-webkit-scrollbar {
 
 .message[data-exit-anim="shrink-up"] {
     animation: shrinkUp var(--fade-out-duration) ease-out forwards !important;
+}
+
+.message[data-exit-anim="dissolve"] {
+    animation: dissolve var(--fade-out-duration) ease-out forwards !important;
+}
+
+.message[data-exit-anim="slide-out-up"] {
+    animation: slideOutUp var(--fade-out-duration) ease-out forwards !important;
+}
+
+.message[data-exit-anim="slide-out-down"] {
+    animation: slideOutDown var(--fade-out-duration) ease-out forwards !important;
+}
+
+.message[data-exit-anim="rotate-out"] {
+    animation: rotateOut var(--fade-out-duration) ease-out forwards !important;
+}
+
+.message[data-exit-anim="pixelate-out"] {
+    animation: pixelateOut var(--fade-out-duration) ease-out forwards !important;
 }
 
 .message.no-timestamp .timestamp {
@@ -635,4 +930,23 @@ body::-webkit-scrollbar {
 .new-messages-indicator-arrow {
     font-size: 14px;
     line-height: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .message,
+    .message::before,
+    .message::after,
+    .message .emote,
+    .message .avatar,
+    .message .username,
+    #new-messages-indicator {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        animation-delay: 0ms !important;
+        transition-duration: 1ms !important;
+    }
+
+    .emote.animated {
+        animation: none !important;
+    }
 }

--- a/PoproshaykaBot.Core/Assets/obs.js
+++ b/PoproshaykaBot.Core/Assets/obs.js
@@ -768,6 +768,37 @@
         console.log('Настройки чата обновлены:', settings);
     }
 
+    const reloadBannerLifetimeMs = 5000;
+    const reloadBannerFadeMs = 600;
+
+    function showReloadBanner() {
+        const now = new Date();
+
+        const banner = document.createElement('div');
+        banner.classList.add('message', 'reload-banner', 'no-animation', 'entry-done');
+        banner.style.transition = 'opacity ' + reloadBannerFadeMs + 'ms ease';
+
+        const timeElement = document.createElement('time');
+        timeElement.className = 'timestamp';
+        timeElement.dateTime = now.toISOString();
+        timeElement.textContent = now.toLocaleTimeString();
+
+        const text = document.createElement('span');
+        text.className = 'system-message';
+        text.textContent = '🔁 Чат-источник перезагружен';
+
+        banner.appendChild(timeElement);
+        banner.appendChild(text);
+        chatContainer.appendChild(banner);
+
+        requestAnimationFrame(() => smoothScrollToBottom(true));
+
+        setTimeout(() => {
+            banner.style.opacity = '0';
+            setTimeout(() => banner.remove(), reloadBannerFadeMs);
+        }, reloadBannerLifetimeMs);
+    }
+
     function initOverlay() {
         fetch('/api/chat-settings')
             .then(response => response.json())
@@ -776,7 +807,10 @@
             .then(response => response.json())
             .then(messages => messages.forEach(message => addMessage(message, true)))
             .catch(error => console.error('Ошибка инициализации оверлея:', error))
-            .finally(() => initEventSource());
+            .finally(() => {
+                showReloadBanner();
+                initEventSource();
+            });
     }
 
     initOverlay();

--- a/PoproshaykaBot.Core/Assets/obs.js
+++ b/PoproshaykaBot.Core/Assets/obs.js
@@ -261,7 +261,28 @@
         return classes;
     }
 
-    const validEntryAnimations = new Set(['no-animation', 'slide-in-right', 'slide-in-left', 'fade-in-up', 'bounce-in']);
+    const validEntryAnimations = new Set([
+        'no-animation',
+        'slide-in-right',
+        'slide-in-left',
+        'fade-in-up',
+        'bounce-in',
+        'pop-in',
+        'rubber-band',
+        'tada',
+        'zoom-blur-in',
+        'neon-pulse-in',
+        'materialize',
+        'glitch-in',
+        'power-up',
+        'slam-in',
+        'notification-bell',
+        'hologram',
+        'flip-in-x',
+        'roll-in',
+        'coin-flip',
+        'swoop-in',
+    ]);
 
     function sanitizeEntryAnimation(value, fallback) {
         return validEntryAnimations.has(value) ? value : fallback;
@@ -330,7 +351,18 @@
         };
     }
 
-    const validExitAnimations = new Set(['fade-out', 'slide-out-left', 'slide-out-right', 'scale-down', 'shrink-up']);
+    const validExitAnimations = new Set([
+        'fade-out',
+        'slide-out-left',
+        'slide-out-right',
+        'scale-down',
+        'shrink-up',
+        'dissolve',
+        'slide-out-up',
+        'slide-out-down',
+        'rotate-out',
+        'pixelate-out',
+    ]);
 
     function fadeOutMessage(messageDiv) {
         if (!enableMessageFadeOut) return;

--- a/PoproshaykaBot.Core/Broadcast/StreamSessionStatisticsHandler.cs
+++ b/PoproshaykaBot.Core/Broadcast/StreamSessionStatisticsHandler.cs
@@ -104,6 +104,11 @@ public sealed class StreamSessionStatisticsHandler :
 
     public Task HandleAsync(ChatMessageReceived @event, CancellationToken cancellationToken)
     {
+        if (@event.IsBot)
+        {
+            return Task.CompletedTask;
+        }
+
         lock (_stateLock)
         {
             if (_sessionStartedAt == null)

--- a/PoproshaykaBot.Core/Chat/AudienceTracker.cs
+++ b/PoproshaykaBot.Core/Chat/AudienceTracker.cs
@@ -9,6 +9,8 @@ public sealed class AudienceTracker(SettingsManager settingsManager)
 
     private readonly ConcurrentDictionary<string, string> _userIdToDisplayName = new();
 
+    public int ActiveUserCount => _userIdToDisplayName.Count;
+
     public bool OnUserMessage(string userId, string displayName)
     {
         if (string.IsNullOrWhiteSpace(userId))

--- a/PoproshaykaBot.Core/Chat/ChatMessage.cs
+++ b/PoproshaykaBot.Core/Chat/ChatMessage.cs
@@ -12,6 +12,7 @@ public sealed record ChatMessage(
     bool IsBroadcaster,
     bool IsModerator,
     bool IsVip,
-    bool IsSubscriber);
+    bool IsSubscriber,
+    bool IsBot = false);
 
 public sealed record EmoteOccurrence(string EmoteId, string Name, int StartIndex, int EndIndex);

--- a/PoproshaykaBot.Core/Chat/ChatServiceCollectionExtensions.cs
+++ b/PoproshaykaBot.Core/Chat/ChatServiceCollectionExtensions.cs
@@ -28,6 +28,25 @@ public static class ChatServiceCollectionExtensions
 
         services.AddSingleton<AudienceTracker>();
 
+        RegisterChatCommands(services);
+
+        services.AddSingleton<ChatCommandProcessor>(sp =>
+        {
+            var commands = sp.GetServices<IChatCommand>().ToList();
+            var logger = sp.GetRequiredService<ILogger<ChatCommandProcessor>>();
+            var processor = new ChatCommandProcessor(commands, logger);
+            processor.Register(new HelpCommand(processor.GetAllCommands));
+            return processor;
+        });
+
+        services.AddSingleton<TwitchChatHandler>();
+        services.AddSingleton<IChannelProvider>(sp => sp.GetRequiredService<TwitchChatHandler>());
+
+        return services;
+    }
+
+    private static void RegisterChatCommands(IServiceCollection services)
+    {
         services.AddSingleton<IChatCommand, HelloCommand>();
         services.AddSingleton<IChatCommand, DonateCommand>();
         services.AddSingleton<IChatCommand, HowManyMessagesCommand>();
@@ -43,19 +62,10 @@ public static class ChatServiceCollectionExtensions
         services.AddSingleton<IChatCommand, ProfileCommand>();
         services.AddSingleton<IChatCommand, TitleCommand>();
         services.AddSingleton<IChatCommand, GameCommand>();
-
-        services.AddSingleton<ChatCommandProcessor>(sp =>
-        {
-            var commands = sp.GetServices<IChatCommand>().ToList();
-            var logger = sp.GetRequiredService<ILogger<ChatCommandProcessor>>();
-            var processor = new ChatCommandProcessor(commands, logger);
-            processor.Register(new HelpCommand(processor.GetAllCommands));
-            return processor;
-        });
-
-        services.AddSingleton<TwitchChatHandler>();
-        services.AddSingleton<IChannelProvider>(sp => sp.GetRequiredService<TwitchChatHandler>());
-
-        return services;
+        services.AddSingleton<IChatCommand, LastStreamCommand>();
+        services.AddSingleton<IChatCommand, StreamsCountCommand>();
+        services.AddSingleton<IChatCommand, PeakStreamCommand>();
+        services.AddSingleton<IChatCommand, IWasThereCommand>();
+        services.AddSingleton<IChatCommand, TopStreamsCommand>();
     }
 }

--- a/PoproshaykaBot.Core/Chat/Commands/IWasThereCommand.cs
+++ b/PoproshaykaBot.Core/Chat/Commands/IWasThereCommand.cs
@@ -1,0 +1,39 @@
+﻿using PoproshaykaBot.Core.Statistics;
+
+namespace PoproshaykaBot.Core.Chat.Commands;
+
+public sealed class IWasThereCommand(StreamSessionHistoryStore historyStore) : IChatCommand
+{
+    public string Canonical => "ятамбыл";
+    public IReadOnlyCollection<string> Aliases => ["iwasthere", "attended"];
+    public string Description => "на скольких стримах ты был";
+
+    public bool CanExecute(CommandContext context)
+    {
+        return true;
+    }
+
+    public Task<OutgoingMessage?> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var sessions = historyStore.Load().Sessions;
+
+        if (sessions.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply("Истории стримов пока нет", context.MessageId));
+        }
+
+        var attended = sessions
+            .Where(s => s.Chatters.Exists(c => string.Equals(c.UserId, context.UserId, StringComparison.Ordinal)))
+            .OrderByDescending(s => s.StartedAt)
+            .ToList();
+
+        if (attended.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply("Ты ещё ни на одном завершённом стриме не был", context.MessageId));
+        }
+
+        var lastDate = FormattingUtils.FormatDateTime(attended[0].StartedAt.UtcDateTime);
+        var text = $"🎟 Ты был на {attended.Count} стримах из {sessions.Count} | Последний: {lastDate}";
+        return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply(text, context.MessageId));
+    }
+}

--- a/PoproshaykaBot.Core/Chat/Commands/LastStreamCommand.cs
+++ b/PoproshaykaBot.Core/Chat/Commands/LastStreamCommand.cs
@@ -1,0 +1,36 @@
+﻿using PoproshaykaBot.Core.Statistics;
+
+namespace PoproshaykaBot.Core.Chat.Commands;
+
+public sealed class LastStreamCommand(StreamSessionHistoryStore historyStore) : IChatCommand
+{
+    public string Canonical => "последнийстрим";
+    public IReadOnlyCollection<string> Aliases => ["laststream", "last"];
+    public string Description => "информация о последнем завершённом стриме";
+
+    public bool CanExecute(CommandContext context)
+    {
+        return true;
+    }
+
+    public Task<OutgoingMessage?> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var sessions = historyStore.Load().Sessions;
+
+        if (sessions.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply("Истории стримов пока нет", context.MessageId));
+        }
+
+        var last = sessions.OrderByDescending(s => s.StartedAt).First();
+
+        var title = string.IsNullOrWhiteSpace(last.Title) ? "Без названия" : last.Title;
+        var game = string.IsNullOrWhiteSpace(last.Game) ? "Без категории" : last.Game;
+        var duration = FormattingUtils.FormatTimeSpan(last.Duration);
+        var messages = FormattingUtils.FormatNumber(last.MessageCount);
+        var when = FormattingUtils.FormatDateTime(last.StartedAt.UtcDateTime);
+
+        var text = $"📺 Последний стрим: {title} | {game} | ⏱ {duration} | 💬 {messages} | 👥 пик {last.PeakViewers} | {when}";
+        return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply(text, context.MessageId));
+    }
+}

--- a/PoproshaykaBot.Core/Chat/Commands/PeakStreamCommand.cs
+++ b/PoproshaykaBot.Core/Chat/Commands/PeakStreamCommand.cs
@@ -1,0 +1,42 @@
+﻿using PoproshaykaBot.Core.Statistics;
+
+namespace PoproshaykaBot.Core.Chat.Commands;
+
+public sealed class PeakStreamCommand(StreamSessionHistoryStore historyStore) : IChatCommand
+{
+    public string Canonical => "рекордстрима";
+    public IReadOnlyCollection<string> Aliases => ["peak", "recordstream"];
+    public string Description => "стрим с пиковым числом зрителей";
+
+    public bool CanExecute(CommandContext context)
+    {
+        return true;
+    }
+
+    public Task<OutgoingMessage?> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var sessions = historyStore.Load().Sessions;
+
+        if (sessions.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply("Истории стримов пока нет", context.MessageId));
+        }
+
+        var record = sessions
+            .OrderByDescending(s => s.PeakViewers)
+            .ThenByDescending(s => s.StartedAt)
+            .First();
+
+        if (record.PeakViewers <= 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply("Данных о пике зрителей пока нет", context.MessageId));
+        }
+
+        var title = string.IsNullOrWhiteSpace(record.Title) ? "Без названия" : record.Title;
+        var game = string.IsNullOrWhiteSpace(record.Game) ? "Без категории" : record.Game;
+        var when = FormattingUtils.FormatDateTime(record.StartedAt.UtcDateTime);
+
+        var text = $"🏆 Рекорд: 👥 {record.PeakViewers} — {title} | {game} | {when}";
+        return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Reply(text, context.MessageId));
+    }
+}

--- a/PoproshaykaBot.Core/Chat/Commands/StreamsCountCommand.cs
+++ b/PoproshaykaBot.Core/Chat/Commands/StreamsCountCommand.cs
@@ -1,0 +1,46 @@
+﻿using PoproshaykaBot.Core.Statistics;
+
+namespace PoproshaykaBot.Core.Chat.Commands;
+
+public sealed class StreamsCountCommand(StreamSessionHistoryStore historyStore, TimeProvider timeProvider) : IChatCommand
+{
+    public string Canonical => "стримов";
+    public IReadOnlyCollection<string> Aliases => ["streams", "streamscount"];
+    public string Description => "всего стримов и суммарная длительность";
+
+    public bool CanExecute(CommandContext context)
+    {
+        return true;
+    }
+
+    public Task<OutgoingMessage?> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var sessions = historyStore.Load().Sessions;
+
+        if (sessions.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Normal("Истории стримов пока нет"));
+        }
+
+        var monthAgo = timeProvider.GetUtcNow() - TimeSpan.FromDays(30);
+        var totalDuration = TimeSpan.Zero;
+        var monthCount = 0;
+
+        foreach (var session in sessions)
+        {
+            totalDuration += session.Duration;
+
+            if (session.StartedAt >= monthAgo)
+            {
+                monthCount++;
+            }
+        }
+
+        var total = FormattingUtils.FormatNumber(sessions.Count);
+        var totalDurationText = FormattingUtils.FormatTimeSpan(totalDuration);
+        var month = FormattingUtils.FormatNumber(monthCount);
+
+        var text = $"📺 Всего стримов: {total} | В эфире суммарно: {totalDurationText} | За 30 дней: {month}";
+        return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Normal(text));
+    }
+}

--- a/PoproshaykaBot.Core/Chat/Commands/TopStreamsCommand.cs
+++ b/PoproshaykaBot.Core/Chat/Commands/TopStreamsCommand.cs
@@ -1,0 +1,79 @@
+﻿using PoproshaykaBot.Core.Statistics;
+
+namespace PoproshaykaBot.Core.Chat.Commands;
+
+public sealed class TopStreamsCommand(StreamSessionHistoryStore historyStore) : IChatCommand
+{
+    private static readonly HashSet<string> MessagesKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "сообщения", "сообщ", "сообщ.", "msg", "messages", "m",
+    };
+
+    private static readonly HashSet<string> ViewersKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "зрители", "зр", "viewers", "v", "peak", "пик",
+    };
+
+    public string Canonical => "топстримов";
+    public IReadOnlyCollection<string> Aliases => ["topstreams"];
+    public string Description => "топ стримов по сообщениям (аргумент 'зрители' переключает на пик зрителей, число задаёт длину 1–5)";
+
+    public bool CanExecute(CommandContext context)
+    {
+        return true;
+    }
+
+    public Task<OutgoingMessage?> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    {
+        var count = 3;
+        var byViewers = false;
+
+        foreach (var arg in context.Arguments)
+        {
+            if (int.TryParse(arg, out var requestedCount))
+            {
+                count = Math.Clamp(requestedCount, 1, 5);
+            }
+            else if (ViewersKeywords.Contains(arg))
+            {
+                byViewers = true;
+            }
+            else if (MessagesKeywords.Contains(arg))
+            {
+                byViewers = false;
+            }
+        }
+
+        var sessions = historyStore.Load().Sessions;
+
+        if (sessions.Count == 0)
+        {
+            return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Normal("Истории стримов пока нет"));
+        }
+
+        var ordered = byViewers
+            ? sessions.OrderByDescending(s => s.PeakViewers).ThenByDescending(s => s.StartedAt)
+            : sessions.OrderByDescending(s => s.MessageCount).ThenByDescending(s => s.StartedAt);
+
+        var top = ordered.Take(count).ToList();
+
+        var parts = top.Select((s, i) =>
+        {
+            var title = string.IsNullOrWhiteSpace(s.Title) ? "Без названия" : Truncate(s.Title, 30);
+            var value = byViewers
+                ? $"👥 {s.PeakViewers}"
+                : $"💬 {FormattingUtils.FormatNumber(s.MessageCount)}";
+
+            return $"{i + 1}. {title} ({value})";
+        });
+
+        var header = byViewers ? $"👥 Топ-{top.Count} по пику: " : $"💬 Топ-{top.Count} по сообщениям: ";
+        var text = header + string.Join(", ", parts);
+        return Task.FromResult<OutgoingMessage?>(OutgoingMessage.Normal(text));
+    }
+
+    private static string Truncate(string value, int max)
+    {
+        return value.Length <= max ? value : value[..(max - 1)] + "…";
+    }
+}

--- a/PoproshaykaBot.Core/Chat/Handlers/FarewellMessageHandler.cs
+++ b/PoproshaykaBot.Core/Chat/Handlers/FarewellMessageHandler.cs
@@ -1,4 +1,6 @@
-﻿using PoproshaykaBot.Core.Infrastructure.Events;
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure;
+using PoproshaykaBot.Core.Infrastructure.Events;
 using PoproshaykaBot.Core.Infrastructure.Events.Lifecycle;
 using PoproshaykaBot.Core.Settings;
 
@@ -6,23 +8,26 @@ namespace PoproshaykaBot.Core.Chat.Handlers;
 
 public sealed class FarewellMessageHandler : IEventHandler<BotLifecyclePhaseChanged>, IEventSubscriber, IDisposable
 {
-    private readonly TwitchChatHandler _twitchChatHandler;
+    private readonly IChannelProvider _channelProvider;
     private readonly AudienceTracker _audienceTracker;
-    private readonly TwitchChatMessenger _messenger;
+    private readonly IChatMessenger _messenger;
     private readonly SettingsManager _settingsManager;
+    private readonly ILogger<FarewellMessageHandler> _logger;
     private readonly IDisposable _subscription;
 
     public FarewellMessageHandler(
-        TwitchChatHandler twitchChatHandler,
+        IChannelProvider channelProvider,
         AudienceTracker audienceTracker,
-        TwitchChatMessenger messenger,
+        IChatMessenger messenger,
         SettingsManager settingsManager,
-        IEventBus eventBus)
+        IEventBus eventBus,
+        ILogger<FarewellMessageHandler> logger)
     {
-        _twitchChatHandler = twitchChatHandler;
+        _channelProvider = channelProvider;
         _audienceTracker = audienceTracker;
         _messenger = messenger;
         _settingsManager = settingsManager;
+        _logger = logger;
         _subscription = eventBus.Subscribe(this);
     }
 
@@ -33,39 +38,60 @@ public sealed class FarewellMessageHandler : IEventHandler<BotLifecyclePhaseChan
             return Task.CompletedTask;
         }
 
-        var channel = _twitchChatHandler.Channel;
+        var channel = _channelProvider.Channel;
 
         if (string.IsNullOrWhiteSpace(channel))
         {
+            _logger.LogWarning("Прощальные сообщения пропущены: канал бота не известен (BotJoinedChannel ещё не публиковался или уже сброшен)");
             return Task.CompletedTask;
         }
 
         var messages = new List<string>();
-        var collectiveFarewell = _audienceTracker.CreateCollectiveFarewell();
 
-        if (!string.IsNullOrWhiteSpace(collectiveFarewell))
+        var messageSettings = _settingsManager.Current.Twitch.Messages;
+        var activeUsers = _audienceTracker.ActiveUserCount;
+
+        if (!messageSettings.FarewellEnabled)
         {
-            messages.Add(collectiveFarewell);
+            _logger.LogInformation("Коллективное прощание выключено настройкой Messages.FarewellEnabled");
+        }
+        else if (activeUsers == 0)
+        {
+            _logger.LogInformation("Коллективное прощание пропущено: AudienceTracker пуст — ни одного нефильтрованного сообщения за сессию");
+        }
+        else
+        {
+            var collectiveFarewell = _audienceTracker.CreateCollectiveFarewell();
+
+            if (!string.IsNullOrWhiteSpace(collectiveFarewell))
+            {
+                messages.Add(collectiveFarewell);
+                _logger.LogInformation("Сформировано коллективное прощание для {Count} зрителей", activeUsers);
+            }
         }
 
-        var settings = _settingsManager.Current.Twitch;
-
-        if (settings.Messages.DisconnectionEnabled
-            && !string.IsNullOrWhiteSpace(settings.Messages.Disconnection))
+        if (messageSettings.DisconnectionEnabled
+            && !string.IsNullOrWhiteSpace(messageSettings.Disconnection))
         {
-            messages.Add(settings.Messages.Disconnection);
+            messages.Add(messageSettings.Disconnection);
         }
 
-        if (messages.Count > 0)
+        if (messages.Count == 0)
         {
-            try
-            {
-                _messenger.Send(string.Join(" ", messages));
-            }
-            catch (Exception)
-            {
-                // farewell is best-effort; failure must not block shutdown
-            }
+            _logger.LogDebug("На фазе Disconnecting не сформировано ни одного прощального сообщения");
+            return Task.CompletedTask;
+        }
+
+        var text = string.Join(" ", messages);
+
+        try
+        {
+            _messenger.Send(text);
+            _logger.LogInformation("Прощальное сообщение поставлено в очередь ChatSender ({Length} симв.)", text.Length);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Не удалось поставить прощальное сообщение в очередь ChatSender");
         }
 
         return Task.CompletedTask;

--- a/PoproshaykaBot.Core/Chat/Handlers/StatisticsTrackingHandler.cs
+++ b/PoproshaykaBot.Core/Chat/Handlers/StatisticsTrackingHandler.cs
@@ -22,6 +22,11 @@ public sealed class StatisticsTrackingHandler : IEventHandler<ChatMessageReceive
 
     public Task HandleAsync(ChatMessageReceived @event, CancellationToken cancellationToken)
     {
+        if (@event.IsBot)
+        {
+            return Task.CompletedTask;
+        }
+
         _userStatistics.TrackMessage(@event.UserId, @event.Username);
         _botStatistics.IncrementMessagesProcessed();
         return Task.CompletedTask;

--- a/PoproshaykaBot.Core/Chat/TwitchChatHandler.cs
+++ b/PoproshaykaBot.Core/Chat/TwitchChatHandler.cs
@@ -82,7 +82,8 @@ public sealed class TwitchChatHandler :
 
         var settings = _settingsManager.Current.Twitch;
 
-        var isFirstSeen = _audienceTracker.OnUserMessage(chatMessage.UserId, chatMessage.DisplayName);
+        var isFirstSeen = !chatMessage.IsBot
+                          && _audienceTracker.OnUserMessage(chatMessage.UserId, chatMessage.DisplayName);
 
         var status = GetUserStatusFlags(chatMessage);
 
@@ -97,7 +98,7 @@ public sealed class TwitchChatHandler :
             UserId = chatMessage.UserId,
             DisplayName = chatMessage.DisplayName,
             Message = chatMessage.Message,
-            MessageType = ChatMessageType.UserMessage,
+            MessageType = chatMessage.IsBot ? ChatMessageType.BotResponse : ChatMessageType.UserMessage,
             Status = status,
             IsFirstTime = isFirstSeen,
 
@@ -114,7 +115,14 @@ public sealed class TwitchChatHandler :
             chatMessage.Message,
             status,
             isFirstSeen,
-            historyEntry), cancellationToken);
+            historyEntry,
+            chatMessage.IsBot), cancellationToken);
+
+        if (chatMessage.IsBot)
+        {
+            _logger.LogDebug("[Бот, эхо] {DisplayName}: {Message}", chatMessage.DisplayName, chatMessage.Message);
+            return;
+        }
 
         var context = new CommandContext
         {

--- a/PoproshaykaBot.Core/Infrastructure/Events/Chat/ChatMessageReceived.cs
+++ b/PoproshaykaBot.Core/Infrastructure/Events/Chat/ChatMessageReceived.cs
@@ -1,4 +1,4 @@
-using PoproshaykaBot.Core.Chat;
+﻿using PoproshaykaBot.Core.Chat;
 using PoproshaykaBot.Core.Users;
 
 namespace PoproshaykaBot.Core.Infrastructure.Events.Chat;
@@ -12,4 +12,5 @@ public sealed record ChatMessageReceived(
     string Text,
     UserStatus Status,
     bool IsFirstTime,
-    ChatMessageData HistoryEntry) : EventBase;
+    ChatMessageData HistoryEntry,
+    bool IsBot = false) : EventBase;

--- a/PoproshaykaBot.Core/Infrastructure/Events/Update/UpdateAvailable.cs
+++ b/PoproshaykaBot.Core/Infrastructure/Events/Update/UpdateAvailable.cs
@@ -1,0 +1,3 @@
+﻿namespace PoproshaykaBot.Core.Infrastructure.Events.Update;
+
+public sealed record UpdateAvailable(string Version, string NotesUrl) : EventBase;

--- a/PoproshaykaBot.Core/Obs/ObsAudioSourceSnapshot.cs
+++ b/PoproshaykaBot.Core/Obs/ObsAudioSourceSnapshot.cs
@@ -1,6 +1,6 @@
 ﻿namespace PoproshaykaBot.Core.Obs;
 
-public sealed record ObsMicrophoneSnapshot(
+public sealed record ObsAudioSourceSnapshot(
     string Name,
     string Kind,
     bool IsMuted,

--- a/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
+++ b/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
@@ -4,7 +4,10 @@ public sealed record ObsDashboardSnapshot(
     ObsConnectionSnapshot Connection,
     string? CurrentSceneName,
     bool? IsStreaming,
+    string? StreamTimecode,
     bool? IsRecording,
+    bool? IsRecordingPaused,
+    string? RecordTimecode,
     IReadOnlyList<ObsAudioSourceSnapshot> AudioSources,
     DateTimeOffset UpdatedAt)
 {
@@ -17,6 +20,6 @@ public sealed record ObsDashboardSnapshot(
 
     public static ObsDashboardSnapshot Unavailable(ObsConnectionSnapshot connection)
     {
-        return new(connection, null, null, null, [], DateTimeOffset.Now);
+        return new(connection, null, null, null, null, null, null, [], DateTimeOffset.Now);
     }
 }

--- a/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
+++ b/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
@@ -5,9 +5,13 @@ public sealed record ObsDashboardSnapshot(
     string? CurrentSceneName,
     bool? IsStreaming,
     string? StreamTimecode,
+    double? StreamCongestion,
+    long? StreamSkippedFrames,
+    long? StreamTotalFrames,
     bool? IsRecording,
     bool? IsRecordingPaused,
     string? RecordTimecode,
+    long? RecordBytes,
     IReadOnlyList<ObsAudioSourceSnapshot> AudioSources,
     DateTimeOffset UpdatedAt)
 {
@@ -20,6 +24,7 @@ public sealed record ObsDashboardSnapshot(
 
     public static ObsDashboardSnapshot Unavailable(ObsConnectionSnapshot connection)
     {
-        return new(connection, null, null, null, null, null, null, [], DateTimeOffset.Now);
+        return new(connection, null, null, null, null, null, null, null,
+            null, null, null, [], DateTimeOffset.Now);
     }
 }

--- a/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
+++ b/PoproshaykaBot.Core/Obs/ObsDashboardSnapshot.cs
@@ -5,7 +5,7 @@ public sealed record ObsDashboardSnapshot(
     string? CurrentSceneName,
     bool? IsStreaming,
     bool? IsRecording,
-    ObsMicrophoneSnapshot? Microphone,
+    IReadOnlyList<ObsAudioSourceSnapshot> AudioSources,
     DateTimeOffset UpdatedAt)
 {
     public bool IsConnected => Connection.IsConnected;
@@ -17,6 +17,6 @@ public sealed record ObsDashboardSnapshot(
 
     public static ObsDashboardSnapshot Unavailable(ObsConnectionSnapshot connection)
     {
-        return new(connection, null, null, null, null, DateTimeOffset.Now);
+        return new(connection, null, null, null, [], DateTimeOffset.Now);
     }
 }

--- a/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
+++ b/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
@@ -148,15 +148,18 @@ public sealed class ObsIntegrationService(
             try
             {
                 var sceneName = await GetCurrentProgramSceneNameAsync(cts.Token).ConfigureAwait(false);
-                var isStreaming = await GetOutputActiveAsync("GetStreamStatus", cts.Token).ConfigureAwait(false);
-                var isRecording = await GetOutputActiveAsync("GetRecordStatus", cts.Token).ConfigureAwait(false);
+                var streamStatus = await GetStreamStatusAsync(cts.Token).ConfigureAwait(false);
+                var recordStatus = await GetRecordStatusAsync(cts.Token).ConfigureAwait(false);
                 var audioSources = await GetAudioSourceSnapshotsAsync(settings, cts.Token)
                     .ConfigureAwait(false);
 
                 return new(connection,
                     sceneName,
-                    isStreaming,
-                    isRecording,
+                    streamStatus.Active,
+                    streamStatus.Timecode,
+                    recordStatus.Active,
+                    recordStatus.Paused,
+                    recordStatus.Timecode,
                     audioSources,
                     DateTimeOffset.Now);
             }
@@ -454,10 +457,32 @@ public sealed class ObsIntegrationService(
             : GetOptionalString(response.Value, "currentProgramSceneName");
     }
 
-    private async Task<bool?> GetOutputActiveAsync(string requestType, CancellationToken cancellationToken)
+    private async Task<(bool? Active, string? Timecode)> GetStreamStatusAsync(CancellationToken cancellationToken)
     {
-        var response = await client.SendRequestAsync(requestType, null, cancellationToken).ConfigureAwait(false);
-        return response is null ? null : GetOptionalBool(response.Value, "outputActive");
+        var response = await client.SendRequestAsync("GetStreamStatus", null, cancellationToken).ConfigureAwait(false);
+        if (response is null)
+        {
+            return (null, null);
+        }
+
+        var data = response.Value;
+        return (GetOptionalBool(data, "outputActive"),
+            GetOptionalString(data, "outputTimecode"));
+    }
+
+    private async Task<(bool? Active, bool? Paused, string? Timecode)> GetRecordStatusAsync(
+        CancellationToken cancellationToken)
+    {
+        var response = await client.SendRequestAsync("GetRecordStatus", null, cancellationToken).ConfigureAwait(false);
+        if (response is null)
+        {
+            return (null, null, null);
+        }
+
+        var data = response.Value;
+        return (GetOptionalBool(data, "outputActive"),
+            GetOptionalBool(data, "outputPaused"),
+            GetOptionalString(data, "outputTimecode"));
     }
 
     private async Task<IReadOnlyList<ObsAudioSourceSnapshot>> GetAudioSourceSnapshotsAsync(

--- a/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
+++ b/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
@@ -150,14 +150,14 @@ public sealed class ObsIntegrationService(
                 var sceneName = await GetCurrentProgramSceneNameAsync(cts.Token).ConfigureAwait(false);
                 var isStreaming = await GetOutputActiveAsync("GetStreamStatus", cts.Token).ConfigureAwait(false);
                 var isRecording = await GetOutputActiveAsync("GetRecordStatus", cts.Token).ConfigureAwait(false);
-                var microphone = await GetMicrophoneSnapshotAsync(settings.DashboardMicrophoneName, cts.Token)
+                var audioSources = await GetAudioSourceSnapshotsAsync(settings, cts.Token)
                     .ConfigureAwait(false);
 
                 return new(connection,
                     sceneName,
                     isStreaming,
                     isRecording,
-                    microphone,
+                    audioSources,
                     DateTimeOffset.Now);
             }
             catch (Exception exception) when (exception is not OperationCanceledException)
@@ -460,57 +460,67 @@ public sealed class ObsIntegrationService(
         return response is null ? null : GetOptionalBool(response.Value, "outputActive");
     }
 
-    private async Task<ObsMicrophoneSnapshot?> GetMicrophoneSnapshotAsync(
-        string configuredMicrophoneName,
+    private async Task<IReadOnlyList<ObsAudioSourceSnapshot>> GetAudioSourceSnapshotsAsync(
+        ObsIntegrationSettings settings,
         CancellationToken cancellationToken)
     {
         var inputs = await GetInputListAsync(cancellationToken).ConfigureAwait(false);
-        ObsInputInfo? microphone;
+        var configuredNames = settings.GetDashboardSourceNames();
 
-        if (string.IsNullOrWhiteSpace(configuredMicrophoneName))
+        if (configuredNames.Count == 0)
         {
-            microphone = inputs
+            var autoMicrophone = inputs
                 .Select(input => new { Input = input, Score = GetMicrophoneCandidateScore(input) })
                 .Where(candidate => candidate.Score > 0)
                 .OrderByDescending(candidate => candidate.Score)
                 .ThenBy(candidate => candidate.Input.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(candidate => candidate.Input)
                 .FirstOrDefault();
-        }
-        else
-        {
-            var microphoneName = configuredMicrophoneName.Trim();
-            microphone = inputs.FirstOrDefault(input =>
-                string.Equals(input.Name, microphoneName, StringComparison.OrdinalIgnoreCase));
+
+            if (autoMicrophone is null)
+            {
+                return [];
+            }
+
+            return [await GetAudioSourceSnapshotAsync(autoMicrophone, cancellationToken).ConfigureAwait(false)];
         }
 
-        if (microphone is null)
+        var result = new List<ObsAudioSourceSnapshot>();
+        foreach (var configuredName in configuredNames)
         {
-            return null;
+            var input = inputs.FirstOrDefault(candidate =>
+                string.Equals(candidate.Name, configuredName, StringComparison.OrdinalIgnoreCase));
+
+            if (input is null)
+            {
+                continue;
+            }
+
+            result.Add(await GetAudioSourceSnapshotAsync(input, cancellationToken).ConfigureAwait(false));
         }
 
-        return await GetMicrophoneSnapshotAsync(microphone, cancellationToken).ConfigureAwait(false);
+        return result;
     }
 
-    private async Task<ObsMicrophoneSnapshot> GetMicrophoneSnapshotAsync(
-        ObsInputInfo microphone,
+    private async Task<ObsAudioSourceSnapshot> GetAudioSourceSnapshotAsync(
+        ObsInputInfo input,
         CancellationToken cancellationToken)
     {
         var muteResponse = await client.SendRequestAsync("GetInputMute",
-                new { inputName = microphone.Name },
+                new { inputName = input.Name },
                 cancellationToken)
             .ConfigureAwait(false);
 
         var volumeResponse = await client.SendRequestAsync("GetInputVolume",
-                new { inputName = microphone.Name },
+                new { inputName = input.Name },
                 cancellationToken)
             .ConfigureAwait(false);
 
         var muted = muteResponse is not null
                     && (GetOptionalBool(muteResponse.Value, "inputMuted") ?? false);
 
-        return new(microphone.Name,
-            microphone.UnversionedKind,
+        return new(input.Name,
+            input.UnversionedKind,
             muted,
             volumeResponse is null ? null : GetOptionalDouble(volumeResponse.Value, "inputVolumeDb"),
             volumeResponse is null ? null : GetOptionalDouble(volumeResponse.Value, "inputVolumeMul"));

--- a/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
+++ b/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
@@ -157,9 +157,13 @@ public sealed class ObsIntegrationService(
                     sceneName,
                     streamStatus.Active,
                     streamStatus.Timecode,
+                    streamStatus.Congestion,
+                    streamStatus.SkippedFrames,
+                    streamStatus.TotalFrames,
                     recordStatus.Active,
                     recordStatus.Paused,
                     recordStatus.Timecode,
+                    recordStatus.Bytes,
                     audioSources,
                     DateTimeOffset.Now);
             }
@@ -266,6 +270,31 @@ public sealed class ObsIntegrationService(
         }
     }
 
+    public Task StartStreamAsync(CancellationToken cancellationToken)
+    {
+        return InvokeOutputRequestAsync("StartStream", cancellationToken);
+    }
+
+    public Task StopStreamAsync(CancellationToken cancellationToken)
+    {
+        return InvokeOutputRequestAsync("StopStream", cancellationToken);
+    }
+
+    public Task StartRecordAsync(CancellationToken cancellationToken)
+    {
+        return InvokeOutputRequestAsync("StartRecord", cancellationToken);
+    }
+
+    public Task StopRecordAsync(CancellationToken cancellationToken)
+    {
+        return InvokeOutputRequestAsync("StopRecord", cancellationToken);
+    }
+
+    public Task ToggleRecordPauseAsync(CancellationToken cancellationToken)
+    {
+        return InvokeOutputRequestAsync("ToggleRecordPause", cancellationToken);
+    }
+
     public void Dispose()
     {
         _operationGate.Dispose();
@@ -330,6 +359,15 @@ public sealed class ObsIntegrationService(
             : null;
     }
 
+    private static long? GetOptionalLong(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var value)
+               && value.ValueKind == JsonValueKind.Number
+               && value.TryGetInt64(out var parsed)
+            ? parsed
+            : null;
+    }
+
     private static bool IsMicrophoneInputKind(string kind)
     {
         return kind.Equals("wasapi_input_capture", StringComparison.OrdinalIgnoreCase)
@@ -348,6 +386,26 @@ public sealed class ObsIntegrationService(
         }
 
         return score;
+    }
+
+    private async Task InvokeOutputRequestAsync(string requestType, CancellationToken cancellationToken)
+    {
+        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (!client.IsConnected)
+            {
+                throw new InvalidOperationException("OBS не подключён");
+            }
+
+            using var cts = CreateTimeoutToken(cancellationToken);
+            await client.SendRequestAsync(requestType, null, cts.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _operationGate.Release();
+        }
     }
 
     private async Task<bool> CreateOrUpdateBrowserSourceAsync(
@@ -457,32 +515,35 @@ public sealed class ObsIntegrationService(
             : GetOptionalString(response.Value, "currentProgramSceneName");
     }
 
-    private async Task<(bool? Active, string? Timecode)> GetStreamStatusAsync(CancellationToken cancellationToken)
+    private async Task<StreamStatusFields> GetStreamStatusAsync(CancellationToken cancellationToken)
     {
         var response = await client.SendRequestAsync("GetStreamStatus", null, cancellationToken).ConfigureAwait(false);
         if (response is null)
         {
-            return (null, null);
+            return new(null, null, null, null, null);
         }
 
         var data = response.Value;
-        return (GetOptionalBool(data, "outputActive"),
-            GetOptionalString(data, "outputTimecode"));
+        return new(GetOptionalBool(data, "outputActive"),
+            GetOptionalString(data, "outputTimecode"),
+            GetOptionalDouble(data, "outputCongestion"),
+            GetOptionalLong(data, "outputSkippedFrames"),
+            GetOptionalLong(data, "outputTotalFrames"));
     }
 
-    private async Task<(bool? Active, bool? Paused, string? Timecode)> GetRecordStatusAsync(
-        CancellationToken cancellationToken)
+    private async Task<RecordStatusFields> GetRecordStatusAsync(CancellationToken cancellationToken)
     {
         var response = await client.SendRequestAsync("GetRecordStatus", null, cancellationToken).ConfigureAwait(false);
         if (response is null)
         {
-            return (null, null, null);
+            return new(null, null, null, null);
         }
 
         var data = response.Value;
-        return (GetOptionalBool(data, "outputActive"),
+        return new(GetOptionalBool(data, "outputActive"),
             GetOptionalBool(data, "outputPaused"),
-            GetOptionalString(data, "outputTimecode"));
+            GetOptionalString(data, "outputTimecode"),
+            GetOptionalLong(data, "outputBytes"));
     }
 
     private async Task<IReadOnlyList<ObsAudioSourceSnapshot>> GetAudioSourceSnapshotsAsync(
@@ -706,4 +767,17 @@ public sealed class ObsIntegrationService(
     private sealed record ObsSceneInfo(string Name);
 
     private sealed record ObsInputInfo(string Name, string Kind, string UnversionedKind);
+
+    private sealed record StreamStatusFields(
+        bool? Active,
+        string? Timecode,
+        double? Congestion,
+        long? SkippedFrames,
+        long? TotalFrames);
+
+    private sealed record RecordStatusFields(
+        bool? Active,
+        bool? Paused,
+        string? Timecode,
+        long? Bytes);
 }

--- a/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
+++ b/PoproshaykaBot.Core/Obs/ObsIntegrationService.cs
@@ -25,6 +25,16 @@ public sealed class ObsIntegrationService(
             new(2, nameof(LogBrowserSourceRefreshFailed)),
             "Не удалось обновить Browser Source {SourceName} через refreshnocache");
 
+    private static readonly Action<ILogger, string, Exception?> LogChatSourceRefreshed =
+        LoggerMessage.Define<string>(LogLevel.Information,
+            new(3, nameof(LogChatSourceRefreshed)),
+            "Browser Source {SourceName}: выполнен жёсткий refresh (refreshnocache)");
+
+    private static readonly Action<ILogger, string, Exception?> LogChatSourceRefreshRejected =
+        LoggerMessage.Define<string>(LogLevel.Warning,
+            new(4, nameof(LogChatSourceRefreshRejected)),
+            "OBS отклонил жёсткий refresh для источника {SourceName}: возможно, источник не Browser Source или не существует");
+
     private readonly SemaphoreSlim _operationGate = new(1, 1);
 
     public ObsConnectionSnapshot CurrentStatus { get; private set; } = ObsConnectionSnapshot.Disconnected();
@@ -113,6 +123,79 @@ public sealed class ObsIntegrationService(
                     .Select(input => input.Name)
                     .Order(StringComparer.OrdinalIgnoreCase),
             ];
+        }
+        finally
+        {
+            _operationGate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> ListBrowserSourceNamesAsync(ObsIntegrationSettings settings, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            using var cts = CreateTimeoutToken(cancellationToken);
+            await EnsureConnectedAsync(settings, cts.Token).ConfigureAwait(false);
+
+            var inputs = await GetInputListAsync(cts.Token).ConfigureAwait(false);
+            return
+            [
+                .. inputs
+                    .Where(input => string.Equals(input.Kind, "browser_source", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(input.UnversionedKind, "browser_source", StringComparison.OrdinalIgnoreCase))
+                    .Select(input => input.Name)
+                    .Order(StringComparer.OrdinalIgnoreCase),
+            ];
+        }
+        finally
+        {
+            _operationGate.Release();
+        }
+    }
+
+    public async Task<int> RefreshConfiguredChatSourcesAsync(
+        ObsIntegrationSettings settings,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var sourceNames = settings.GetChatRefreshSourceNames();
+        if (sourceNames.Count == 0)
+        {
+            return 0;
+        }
+
+        await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            using var cts = CreateTimeoutToken(cancellationToken);
+            await EnsureConnectedAsync(settings, cts.Token).ConfigureAwait(false);
+
+            var refreshed = 0;
+            foreach (var sourceName in sourceNames)
+            {
+                try
+                {
+                    await client.SendRequestAsync("PressInputPropertiesButton",
+                            new { inputName = sourceName, propertyName = "refreshnocache" },
+                            cts.Token)
+                        .ConfigureAwait(false);
+
+                    LogChatSourceRefreshed(logger, sourceName, null);
+                    refreshed++;
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    LogChatSourceRefreshRejected(logger, sourceName, exception);
+                }
+            }
+
+            return refreshed;
         }
         finally
         {

--- a/PoproshaykaBot.Core/Obs/ObsServiceCollectionExtensions.cs
+++ b/PoproshaykaBot.Core/Obs/ObsServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ObsServiceCollectionExtensions
         services.AddSingleton<IObsSceneController>(sp => sp.GetRequiredService<ObsIntegrationService>());
         services.AddSingleton<IAppLifetimeComponent, ObsIntegrationLifetimeAdapter>();
         services.AddSingleton<IAppLifetimeComponent, ObsSceneEventBridge>();
+        services.AddSingleton<IAppLifetimeComponent, ObsStreamStartChatRefresher>();
 
         return services;
     }

--- a/PoproshaykaBot.Core/Obs/ObsStreamStartChatRefresher.cs
+++ b/PoproshaykaBot.Core/Obs/ObsStreamStartChatRefresher.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure.Hosting;
+using PoproshaykaBot.Core.Settings.Stores;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Obs;
+
+internal sealed class ObsStreamStartChatRefresher(
+    IObsWebSocketClient client,
+    ObsIntegrationStore store,
+    ObsIntegrationService integration,
+    ILogger<ObsStreamStartChatRefresher> logger)
+    : IAppLifetimeComponent
+{
+    private const string StreamStateChangedEvent = "StreamStateChanged";
+
+    private bool _lastActive;
+
+    public string Name => "OBS авто-refresh чата при старте эфира";
+
+    public int StartOrder => 12;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        client.EventReceived += OnObsEventReceived;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        client.EventReceived -= OnObsEventReceived;
+        return Task.CompletedTask;
+    }
+
+    private void OnObsEventReceived(object? sender, ObsWebSocketEventArgs e)
+    {
+        if (!string.Equals(e.EventType, StreamStateChangedEvent, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (e.EventData is not { } data
+            || !data.TryGetProperty("outputActive", out var activeElement)
+            || activeElement.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            return;
+        }
+
+        var active = activeElement.GetBoolean();
+        var wasActive = _lastActive;
+        _lastActive = active;
+
+        if (!active || wasActive)
+        {
+            return;
+        }
+
+        var settings = store.Load();
+        if (!settings.Enabled || !settings.RefreshChatSourcesOnStreamStart)
+        {
+            return;
+        }
+
+        _ = RefreshSafeAsync();
+    }
+
+    private async Task RefreshSafeAsync()
+    {
+        try
+        {
+            var settings = store.Load();
+            var refreshed = await integration
+                .RefreshConfiguredChatSourcesAsync(settings, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (refreshed > 0)
+            {
+                logger.LogInformation("Старт эфира OBS: обновлено чат-источников {Count}", refreshed);
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception,
+                "Не удалось обновить чат-источники OBS при старте эфира");
+        }
+    }
+}

--- a/PoproshaykaBot.Core/PoproshaykaBot.Core.csproj
+++ b/PoproshaykaBot.Core/PoproshaykaBot.Core.csproj
@@ -24,6 +24,9 @@
     <EmbeddedResource Include="Assets\oauth-success.html" />
     <EmbeddedResource Include="Assets\oauth-error.html" />
     <EmbeddedResource Include="Assets\animations-demo.html" />
+    <EmbeddedResource Include="Assets\animations-demo.css" />
+    <EmbeddedResource Include="Assets\animations-demo.js" />
+    <EmbeddedResource Include="Assets\animations-demo-config.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PoproshaykaBot.Core/PoproshaykaBot.Core.csproj
+++ b/PoproshaykaBot.Core/PoproshaykaBot.Core.csproj
@@ -23,6 +23,7 @@
     <EmbeddedResource Include="Assets\icon.ico" />
     <EmbeddedResource Include="Assets\oauth-success.html" />
     <EmbeddedResource Include="Assets\oauth-error.html" />
+    <EmbeddedResource Include="Assets\animations-demo.html" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PoproshaykaBot.Core/Server/Endpoints/AnimationsEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/AnimationsEndpoint.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using PoproshaykaBot.Core.Settings.Obs;
+
+namespace PoproshaykaBot.Core.Server.Endpoints;
+
+internal sealed class AnimationsEndpoint : IEndpointMapper
+{
+    public void Map(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/animations", () =>
+        {
+            var payload = new AnimationsResponse
+            {
+                Entry = MessageAnimationType.EntryAnimations
+                    .Select(a => new AnimationOption(a.Value, a.DisplayName))
+                    .ToArray(),
+                Exit = MessageAnimationType.ExitAnimations
+                    .Select(a => new AnimationOption(a.Value, a.DisplayName))
+                    .ToArray(),
+            };
+
+            return Results.Json(payload, ServerJsonOptions.Default);
+        });
+    }
+
+    private sealed record AnimationOption(string Value, string Label);
+
+    private sealed class AnimationsResponse
+    {
+        public IReadOnlyList<AnimationOption> Entry { get; init; } = [];
+        public IReadOnlyList<AnimationOption> Exit { get; init; } = [];
+    }
+}

--- a/PoproshaykaBot.Core/Server/Endpoints/AvatarEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/AvatarEndpoint.cs
@@ -1,24 +1,40 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using PoproshaykaBot.Core.Twitch;
+using PoproshaykaBot.Core.Twitch.Helix;
 using PoproshaykaBot.Core.Users;
 
 namespace PoproshaykaBot.Core.Server.Endpoints;
 
-internal sealed class AvatarEndpoint(UserProfileImageProvider userProfileImageProvider) : IEndpointMapper
+internal sealed class AvatarEndpoint(
+    UserProfileImageProvider userProfileImageProvider,
+    IServiceProvider serviceProvider) : IEndpointMapper
 {
     public void Map(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("/api/user-avatar", async (HttpContext ctx) =>
         {
             var userId = ctx.Request.Query["id"].FirstOrDefault();
+            var login = ctx.Request.Query["login"].FirstOrDefault();
 
-            if (string.IsNullOrWhiteSpace(userId))
+            if (string.IsNullOrWhiteSpace(userId) && string.IsNullOrWhiteSpace(login))
             {
                 return Results.BadRequest();
             }
 
-            var url = await userProfileImageProvider.GetAsync(userId, ctx.RequestAborted);
+            string? url;
+            if (!string.IsNullOrWhiteSpace(userId))
+            {
+                url = await userProfileImageProvider.GetAsync(userId, ctx.RequestAborted);
+            }
+            else
+            {
+                var helix = serviceProvider.GetRequiredKeyedService<ITwitchHelixClient>(TwitchEndpoints.HelixBotClient);
+                var user = await helix.GetUserByLoginAsync(login!, ctx.RequestAborted);
+                url = user?.ProfileImageUrl;
+            }
 
             if (string.IsNullOrEmpty(url))
             {

--- a/PoproshaykaBot.Core/Server/Endpoints/ChatSettingsEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/ChatSettingsEndpoint.cs
@@ -1,12 +1,15 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using PoproshaykaBot.Core.Server.Obs;
+using PoproshaykaBot.Core.Settings.Obs;
 using PoproshaykaBot.Core.Settings.Stores;
+using System.Text.Json;
 
 namespace PoproshaykaBot.Core.Server.Endpoints;
 
-internal sealed class ChatSettingsEndpoint(ObsChatStore obsChatStore) : IEndpointMapper
+internal sealed class ChatSettingsEndpoint(ObsChatStore obsChatStore, ILogger<ChatSettingsEndpoint>? logger = null) : IEndpointMapper
 {
     public void Map(IEndpointRouteBuilder endpoints)
     {
@@ -15,6 +18,31 @@ internal sealed class ChatSettingsEndpoint(ObsChatStore obsChatStore) : IEndpoin
             var settings = obsChatStore.Load();
             var cssSettings = ObsChatCssSettings.FromObsChatSettings(settings);
             return Results.Json(cssSettings, ServerJsonOptions.Default);
+        });
+
+        endpoints.MapPost("/api/chat-settings", async (HttpRequest request, CancellationToken cancellationToken) =>
+        {
+            ObsChatSettings? incoming;
+            try
+            {
+                incoming = await JsonSerializer.DeserializeAsync<ObsChatSettings>(request.Body, JsonStoreOptions.Default, cancellationToken);
+            }
+            catch (JsonException exception)
+            {
+                logger?.LogWarning(exception, "POST /api/chat-settings: ошибка разбора JSON");
+                return Results.BadRequest(new { error = "Не удалось разобрать JSON.", details = exception.Message });
+            }
+
+            if (incoming == null)
+            {
+                return Results.BadRequest(new { error = "Тело запроса пустое." });
+            }
+
+            var normalized = ObsChatSettingsValidator.Clamp(incoming);
+            obsChatStore.Save(normalized);
+
+            logger?.LogInformation("POST /api/chat-settings: настройки чата применены через HTTP API");
+            return Results.Ok(new { ok = true });
         });
     }
 }

--- a/PoproshaykaBot.Core/Server/Endpoints/ChatSettingsEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/ChatSettingsEndpoint.cs
@@ -20,6 +20,17 @@ internal sealed class ChatSettingsEndpoint(ObsChatStore obsChatStore, ILogger<Ch
             return Results.Json(cssSettings, ServerJsonOptions.Default);
         });
 
+        endpoints.MapGet("/api/chat-settings/raw", () =>
+        {
+            var settings = obsChatStore.Load();
+            return Results.Json(settings, ServerJsonOptions.WithColors);
+        });
+
+        endpoints.MapGet("/api/chat-settings/schema", () =>
+        {
+            return Results.Json(ObsChatRangesSchema.All, ServerJsonOptions.Default);
+        });
+
         endpoints.MapPost("/api/chat-settings", async (HttpRequest request, CancellationToken cancellationToken) =>
         {
             ObsChatSettings? incoming;

--- a/PoproshaykaBot.Core/Server/Endpoints/StaticAssetsEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/StaticAssetsEndpoint.cs
@@ -7,6 +7,7 @@ namespace PoproshaykaBot.Core.Server.Endpoints;
 internal sealed class StaticAssetsEndpoint : IEndpointMapper
 {
     private static readonly string OverlayHtml = ResourceLoader.LoadResourceText("PoproshaykaBot.Core.Assets.ObsOverlay.html");
+    private static readonly string AnimationsDemoHtml = ResourceLoader.LoadResourceText("PoproshaykaBot.Core.Assets.animations-demo.html");
     private static readonly byte[] ObsCssBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.obs.css");
     private static readonly byte[] ObsJsBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.obs.js");
     private static readonly byte[] FaviconBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.icon.ico");
@@ -14,6 +15,7 @@ internal sealed class StaticAssetsEndpoint : IEndpointMapper
     public void Map(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("/chat", () => Results.Content(OverlayHtml, "text/html; charset=utf-8"));
+        endpoints.MapGet("/animations-demo", () => Results.Content(AnimationsDemoHtml, "text/html; charset=utf-8"));
         endpoints.MapGet("/assets/obs.css", () => Results.Bytes(ObsCssBytes, "text/css; charset=utf-8"));
         endpoints.MapGet("/assets/obs.js", () => Results.Bytes(ObsJsBytes, "application/javascript; charset=utf-8"));
         endpoints.MapGet("/favicon.ico", () => Results.Bytes(FaviconBytes, "image/x-icon"));

--- a/PoproshaykaBot.Core/Server/Endpoints/StaticAssetsEndpoint.cs
+++ b/PoproshaykaBot.Core/Server/Endpoints/StaticAssetsEndpoint.cs
@@ -10,6 +10,9 @@ internal sealed class StaticAssetsEndpoint : IEndpointMapper
     private static readonly string AnimationsDemoHtml = ResourceLoader.LoadResourceText("PoproshaykaBot.Core.Assets.animations-demo.html");
     private static readonly byte[] ObsCssBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.obs.css");
     private static readonly byte[] ObsJsBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.obs.js");
+    private static readonly byte[] AnimationsDemoCssBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.animations-demo.css");
+    private static readonly byte[] AnimationsDemoJsBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.animations-demo.js");
+    private static readonly byte[] AnimationsDemoConfigJsBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.animations-demo-config.js");
     private static readonly byte[] FaviconBytes = ResourceLoader.LoadResourceBytes("PoproshaykaBot.Core.Assets.icon.ico");
 
     public void Map(IEndpointRouteBuilder endpoints)
@@ -18,6 +21,9 @@ internal sealed class StaticAssetsEndpoint : IEndpointMapper
         endpoints.MapGet("/animations-demo", () => Results.Content(AnimationsDemoHtml, "text/html; charset=utf-8"));
         endpoints.MapGet("/assets/obs.css", () => Results.Bytes(ObsCssBytes, "text/css; charset=utf-8"));
         endpoints.MapGet("/assets/obs.js", () => Results.Bytes(ObsJsBytes, "application/javascript; charset=utf-8"));
+        endpoints.MapGet("/assets/animations-demo.css", () => Results.Bytes(AnimationsDemoCssBytes, "text/css; charset=utf-8"));
+        endpoints.MapGet("/assets/animations-demo.js", () => Results.Bytes(AnimationsDemoJsBytes, "application/javascript; charset=utf-8"));
+        endpoints.MapGet("/assets/animations-demo-config.js", () => Results.Bytes(AnimationsDemoConfigJsBytes, "application/javascript; charset=utf-8"));
         endpoints.MapGet("/favicon.ico", () => Results.Bytes(FaviconBytes, "image/x-icon"));
     }
 }

--- a/PoproshaykaBot.Core/Server/KestrelHttpServer.cs
+++ b/PoproshaykaBot.Core/Server/KestrelHttpServer.cs
@@ -39,22 +39,12 @@ public sealed class KestrelHttpServer(
 
             builder.Services.AddSingleton(loggerFactory);
 
-            builder.Services.AddCors(options =>
-            {
-                options.AddDefaultPolicy(policy =>
-                    policy.AllowAnyOrigin()
-                        .AllowAnyHeader()
-                        .AllowAnyMethod());
-            });
-
             builder.WebHost.ConfigureKestrel(options =>
             {
                 options.ListenLocalhost(port);
             });
 
             _app = builder.Build();
-
-            _app.UseCors();
 
             _app.Use(async (ctx, next) =>
             {

--- a/PoproshaykaBot.Core/Server/ServerJsonOptions.cs
+++ b/PoproshaykaBot.Core/Server/ServerJsonOptions.cs
@@ -1,3 +1,4 @@
+﻿using PoproshaykaBot.Core.Settings.Stores;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
@@ -10,5 +11,13 @@ internal static class ServerJsonOptions
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         WriteIndented = false,
+    };
+
+    public static readonly JsonSerializerOptions WithColors = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = false,
+        Converters = { new ColorJsonConverter() },
     };
 }

--- a/PoproshaykaBot.Core/Server/ServerServiceCollectionExtensions.cs
+++ b/PoproshaykaBot.Core/Server/ServerServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServerServiceCollectionExtensions
         services.AddSingleton<IEndpointMapper, SseEndpoint>();
         services.AddSingleton<IEndpointMapper, ChatHistoryEndpoint>();
         services.AddSingleton<IEndpointMapper, ChatSettingsEndpoint>();
+        services.AddSingleton<IEndpointMapper, AnimationsEndpoint>();
         services.AddSingleton<IEndpointMapper, AvatarEndpoint>();
         services.AddSingleton<IEndpointMapper, StaticAssetsEndpoint>();
 

--- a/PoproshaykaBot.Core/Server/SseChatSettingsSyncHandler.cs
+++ b/PoproshaykaBot.Core/Server/SseChatSettingsSyncHandler.cs
@@ -1,4 +1,4 @@
-using PoproshaykaBot.Core.Infrastructure.Events;
+﻿using PoproshaykaBot.Core.Infrastructure.Events;
 using PoproshaykaBot.Core.Infrastructure.Events.Settings;
 
 namespace PoproshaykaBot.Core.Server;
@@ -17,6 +17,7 @@ public sealed class SseChatSettingsSyncHandler : IEventHandler<ChatSettingsChang
     public Task HandleAsync(ChatSettingsChangedEvent @event, CancellationToken cancellationToken)
     {
         _sseService.NotifyChatSettingsChanged(@event.Settings);
+        _sseService.NotifyChatSettingsChangedRaw(@event.Settings);
         return Task.CompletedTask;
     }
 

--- a/PoproshaykaBot.Core/Server/SseService.cs
+++ b/PoproshaykaBot.Core/Server/SseService.cs
@@ -213,6 +213,21 @@ public sealed class SseService : IAsyncDisposable
         }
     }
 
+    public void NotifyChatSettingsChangedRaw(ObsChatSettings settings)
+    {
+        _logger.LogDebug("Подготовка raw-уведомления об изменении настроек чата");
+
+        try
+        {
+            var json = JsonSerializer.Serialize(settings, ServerJsonOptions.WithColors);
+            Enqueue(new("chat_settings_changed_raw", json));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка подготовки raw-уведомления о настройках чата");
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         _logger.LogDebug("Освобождение ресурсов сервиса SSE (DisposeAsync)");

--- a/PoproshaykaBot.Core/Settings/Obs/MessageAnimationType.cs
+++ b/PoproshaykaBot.Core/Settings/Obs/MessageAnimationType.cs
@@ -5,30 +5,37 @@ namespace PoproshaykaBot.Core.Settings.Obs;
 public static class MessageAnimationType
 {
     public const string None = "no-animation";
+
     public const string SlideInRight = "slide-in-right";
     public const string SlideInLeft = "slide-in-left";
     public const string FadeInUp = "fade-in-up";
     public const string BounceIn = "bounce-in";
+    public const string PopIn = "pop-in";
+    public const string RubberBand = "rubber-band";
+    public const string Tada = "tada";
+    public const string ZoomBlurIn = "zoom-blur-in";
+    public const string NeonPulseIn = "neon-pulse-in";
+    public const string Materialize = "materialize";
+    public const string GlitchIn = "glitch-in";
+    public const string PowerUp = "power-up";
+    public const string SlamIn = "slam-in";
+    public const string NotificationBell = "notification-bell";
+    public const string Hologram = "hologram";
+    public const string FlipInX = "flip-in-x";
+    public const string RollIn = "roll-in";
+    public const string CoinFlip = "coin-flip";
+    public const string SwoopIn = "swoop-in";
 
     public const string FadeOut = "fade-out";
     public const string SlideOutLeft = "slide-out-left";
     public const string SlideOutRight = "slide-out-right";
     public const string ScaleDown = "scale-down";
     public const string ShrinkUp = "shrink-up";
-
-    public static readonly string[] DisplayNames =
-    [
-        "Без анимации",
-        "Скольжение справа",
-        "Скольжение слева",
-        "Затухание сверху",
-        "Прыжок",
-        "Исчезновение",
-        "Выскользнуть влево",
-        "Выскользнуть вправо",
-        "Уменьшение",
-        "Свернуться вверх",
-    ];
+    public const string Dissolve = "dissolve";
+    public const string SlideOutUp = "slide-out-up";
+    public const string SlideOutDown = "slide-out-down";
+    public const string RotateOut = "rotate-out";
+    public const string PixelateOut = "pixelate-out";
 
     public static readonly (string Value, string DisplayName)[] EntryAnimations =
     [
@@ -37,6 +44,21 @@ public static class MessageAnimationType
         (SlideInLeft, "Скольжение слева"),
         (FadeInUp, "Затухание сверху"),
         (BounceIn, "Прыжок"),
+        (PopIn, "Поп-ап с упругостью"),
+        (RubberBand, "Резиновая лента"),
+        (Tada, "Та-да!"),
+        (ZoomBlurIn, "Кинонаезд с размытием"),
+        (NeonPulseIn, "Неоновая вспышка"),
+        (Materialize, "Материализация"),
+        (GlitchIn, "Глитч"),
+        (PowerUp, "Усиление снизу"),
+        (SlamIn, "Удар сверху"),
+        (NotificationBell, "Звон уведомления"),
+        (Hologram, "Голограмма"),
+        (FlipInX, "Переворот по горизонтали"),
+        (RollIn, "Вкатывание"),
+        (CoinFlip, "Подброс монеты"),
+        (SwoopIn, "Налёт по диагонали"),
     ];
 
     public static readonly (string Value, string DisplayName)[] ExitAnimations =
@@ -47,6 +69,11 @@ public static class MessageAnimationType
         (SlideOutRight, "Выскользнуть вправо"),
         (ScaleDown, "Уменьшение"),
         (ShrinkUp, "Свернуться вверх"),
+        (Dissolve, "Растворение в пыль"),
+        (SlideOutUp, "Выскользнуть вверх"),
+        (SlideOutDown, "Выскользнуть вниз"),
+        (RotateOut, "Поворот с уходом"),
+        (PixelateOut, "Пикселизация"),
     ];
 
     public static readonly ImmutableArray<string> EntryValues =

--- a/PoproshaykaBot.Core/Settings/Obs/ObsChatRangesSchema.cs
+++ b/PoproshaykaBot.Core/Settings/Obs/ObsChatRangesSchema.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.ObjectModel;
+
+namespace PoproshaykaBot.Core.Settings.Obs;
+
+public sealed record ObsChatRangeSchema(int Min, int Max, int Step);
+
+public static class ObsChatRangesSchema
+{
+    public static IReadOnlyDictionary<string, ObsChatRangeSchema> All { get; } =
+        new ReadOnlyDictionary<string, ObsChatRangeSchema>(new Dictionary<string, ObsChatRangeSchema>(StringComparer.Ordinal)
+        {
+            ["fontSize"] = new(ObsChatRanges.FontSizeMin, ObsChatRanges.FontSizeMax, 1),
+            ["padding"] = new(ObsChatRanges.PaddingMin, ObsChatRanges.PaddingMax, 1),
+            ["margin"] = new(ObsChatRanges.MarginMin, ObsChatRanges.MarginMax, 1),
+            ["borderRadius"] = new(ObsChatRanges.BorderRadiusMin, ObsChatRanges.BorderRadiusMax, 1),
+            ["animationDuration"] = new(ObsChatRanges.AnimationDurationMin, ObsChatRanges.AnimationDurationMax, 50),
+            ["maxMessages"] = new(ObsChatRanges.MaxMessagesMin, ObsChatRanges.MaxMessagesMax, 1),
+            ["emoteSizePixels"] = new(ObsChatRanges.EmoteSizeMin, ObsChatRanges.EmoteSizeMax, 1),
+            ["badgeSizePixels"] = new(ObsChatRanges.BadgeSizeMin, ObsChatRanges.BadgeSizeMax, 1),
+            ["userAvatarSizePixels"] = new(ObsChatRanges.UserAvatarSizeMin, ObsChatRanges.UserAvatarSizeMax, 1),
+            ["scrollAnimationDuration"] = new(ObsChatRanges.ScrollAnimationDurationMin, ObsChatRanges.ScrollAnimationDurationMax, 50),
+            ["scrollToBottomThreshold"] = new(ObsChatRanges.ScrollToBottomThresholdMin, ObsChatRanges.ScrollToBottomThresholdMax, 10),
+            ["scrollPauseAfterUserMs"] = new(ObsChatRanges.ScrollPauseAfterUserMsMin, ObsChatRanges.ScrollPauseAfterUserMsMax, 100),
+            ["messageLifetimeSeconds"] = new(ObsChatRanges.MessageLifetimeMin, ObsChatRanges.MessageLifetimeMax, 1),
+            ["fadeOutAnimationDurationMs"] = new(ObsChatRanges.FadeOutAnimationDurationMin, ObsChatRanges.FadeOutAnimationDurationMax, 50),
+        });
+}

--- a/PoproshaykaBot.Core/Settings/Obs/ObsChatSettingsValidator.cs
+++ b/PoproshaykaBot.Core/Settings/Obs/ObsChatSettingsValidator.cs
@@ -1,0 +1,81 @@
+﻿namespace PoproshaykaBot.Core.Settings.Obs;
+
+public static class ObsChatSettingsValidator
+{
+    public static ObsChatSettings Clamp(ObsChatSettings source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return new()
+        {
+            BackgroundColor = source.BackgroundColor,
+            TextColor = source.TextColor,
+            UsernameColor = source.UsernameColor,
+            SystemMessageColor = source.SystemMessageColor,
+            TimestampColor = source.TimestampColor,
+
+            FontFamily = string.IsNullOrWhiteSpace(source.FontFamily)
+                ? ObsChatSettings.DefaultFontFamily
+                : source.FontFamily,
+            FontSize = ObsChatRanges.Clamp(source.FontSize, ObsChatRanges.FontSizeMin, ObsChatRanges.FontSizeMax),
+            FontBold = source.FontBold,
+
+            Padding = ObsChatRanges.Clamp(source.Padding, ObsChatRanges.PaddingMin, ObsChatRanges.PaddingMax),
+            Margin = ObsChatRanges.Clamp(source.Margin, ObsChatRanges.MarginMin, ObsChatRanges.MarginMax),
+            BorderRadius = ObsChatRanges.Clamp(source.BorderRadius, ObsChatRanges.BorderRadiusMin, ObsChatRanges.BorderRadiusMax),
+
+            AnimationDuration = ObsChatRanges.Clamp(source.AnimationDuration, ObsChatRanges.AnimationDurationMin, ObsChatRanges.AnimationDurationMax),
+            EnableAnimations = source.EnableAnimations,
+
+            MaxMessages = ObsChatRanges.Clamp(source.MaxMessages, ObsChatRanges.MaxMessagesMin, ObsChatRanges.MaxMessagesMax),
+            ShowTimestamp = source.ShowTimestamp,
+
+            EmoteSizePixels = ObsChatRanges.Clamp(source.EmoteSizePixels, ObsChatRanges.EmoteSizeMin, ObsChatRanges.EmoteSizeMax),
+            BadgeSizePixels = ObsChatRanges.Clamp(source.BadgeSizePixels, ObsChatRanges.BadgeSizeMin, ObsChatRanges.BadgeSizeMax),
+
+            ShowUserAvatars = source.ShowUserAvatars,
+            UserAvatarSizePixels = ObsChatRanges.Clamp(source.UserAvatarSizePixels, ObsChatRanges.UserAvatarSizeMin, ObsChatRanges.UserAvatarSizeMax),
+
+            ShowUserTypeBorders = source.ShowUserTypeBorders,
+            HighlightFirstTimeUsers = source.HighlightFirstTimeUsers,
+            HighlightMentions = source.HighlightMentions,
+            EnableMessageShadows = source.EnableMessageShadows,
+            EnableSpecialEffects = source.EnableSpecialEffects,
+
+            EnableSmoothScroll = source.EnableSmoothScroll,
+            ScrollAnimationDuration = ObsChatRanges.Clamp(source.ScrollAnimationDuration, ObsChatRanges.ScrollAnimationDurationMin, ObsChatRanges.ScrollAnimationDurationMax),
+            AutoScrollEnabled = source.AutoScrollEnabled,
+            ScrollToBottomThreshold = ObsChatRanges.Clamp(source.ScrollToBottomThreshold, ObsChatRanges.ScrollToBottomThresholdMin, ObsChatRanges.ScrollToBottomThresholdMax),
+            ScrollPauseAfterUserMs = ObsChatRanges.Clamp(source.ScrollPauseAfterUserMs, ObsChatRanges.ScrollPauseAfterUserMsMin, ObsChatRanges.ScrollPauseAfterUserMsMax),
+
+            UserMessageAnimation = NormalizeAnimation(source.UserMessageAnimation, MessageAnimationType.EntryValues, MessageAnimationType.SlideInRight),
+            BotMessageAnimation = NormalizeAnimation(source.BotMessageAnimation, MessageAnimationType.EntryValues, MessageAnimationType.FadeInUp),
+            SystemMessageAnimation = NormalizeAnimation(source.SystemMessageAnimation, MessageAnimationType.EntryValues, MessageAnimationType.FadeInUp),
+            BroadcasterMessageAnimation = NormalizeAnimation(source.BroadcasterMessageAnimation, MessageAnimationType.EntryValues, MessageAnimationType.SlideInLeft),
+            FirstTimeUserMessageAnimation = NormalizeAnimation(source.FirstTimeUserMessageAnimation, MessageAnimationType.EntryValues, MessageAnimationType.BounceIn),
+
+            EnableMessageFadeOut = source.EnableMessageFadeOut,
+            MessageLifetimeSeconds = ObsChatRanges.Clamp(source.MessageLifetimeSeconds, ObsChatRanges.MessageLifetimeMin, ObsChatRanges.MessageLifetimeMax),
+            FadeOutAnimationType = NormalizeAnimation(source.FadeOutAnimationType, MessageAnimationType.ExitValues, MessageAnimationType.FadeOut),
+            FadeOutAnimationDurationMs = ObsChatRanges.Clamp(source.FadeOutAnimationDurationMs, ObsChatRanges.FadeOutAnimationDurationMin, ObsChatRanges.FadeOutAnimationDurationMax),
+        };
+    }
+
+    private static string NormalizeAnimation(string? incoming, IReadOnlyList<string> allowed, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(incoming))
+        {
+            return fallback;
+        }
+
+        for (var index = 0; index < allowed.Count; index++)
+        {
+            if (string.Equals(allowed[index], incoming, StringComparison.Ordinal))
+            {
+                return incoming;
+            }
+        }
+
+        return fallback;
+    }
+}

--- a/PoproshaykaBot.Core/Settings/Obs/ObsIntegrationSettings.cs
+++ b/PoproshaykaBot.Core/Settings/Obs/ObsIntegrationSettings.cs
@@ -22,6 +22,8 @@ public sealed class ObsIntegrationSettings
 
     public string DashboardMicrophoneName { get; set; } = string.Empty;
 
+    public List<string> DashboardSourceNames { get; set; } = [];
+
     public int DashboardVolumeMeterDelayMs { get; set; } = 120;
 
     public string SourceName { get; set; } = "PoproshaykaBot Chat";
@@ -29,4 +31,20 @@ public sealed class ObsIntegrationSettings
     public int Width { get; set; } = 1920;
 
     public int Height { get; set; } = 1080;
+
+    public IReadOnlyList<string> GetDashboardSourceNames()
+    {
+        if (DashboardSourceNames.Count > 0)
+        {
+            return DashboardSourceNames
+                .Select(name => name?.Trim() ?? string.Empty)
+                .Where(name => name.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        return string.IsNullOrWhiteSpace(DashboardMicrophoneName)
+            ? []
+            : [DashboardMicrophoneName.Trim()];
+    }
 }

--- a/PoproshaykaBot.Core/Settings/Obs/ObsIntegrationSettings.cs
+++ b/PoproshaykaBot.Core/Settings/Obs/ObsIntegrationSettings.cs
@@ -32,6 +32,10 @@ public sealed class ObsIntegrationSettings
 
     public int Height { get; set; } = 1080;
 
+    public List<string> ChatRefreshSources { get; set; } = [];
+
+    public bool RefreshChatSourcesOnStreamStart { get; set; }
+
     public IReadOnlyList<string> GetDashboardSourceNames()
     {
         if (DashboardSourceNames.Count > 0)
@@ -46,5 +50,21 @@ public sealed class ObsIntegrationSettings
         return string.IsNullOrWhiteSpace(DashboardMicrophoneName)
             ? []
             : [DashboardMicrophoneName.Trim()];
+    }
+
+    public IReadOnlyList<string> GetChatRefreshSourceNames()
+    {
+        if (ChatRefreshSources.Count > 0)
+        {
+            return ChatRefreshSources
+                .Select(name => name?.Trim() ?? string.Empty)
+                .Where(name => name.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        return string.IsNullOrWhiteSpace(SourceName)
+            ? []
+            : [SourceName.Trim()];
     }
 }

--- a/PoproshaykaBot.Core/Settings/SettingsServiceCollectionExtensions.cs
+++ b/PoproshaykaBot.Core/Settings/SettingsServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class SettingsServiceCollectionExtensions
         services.AddSingleton<DashboardLayoutStore>();
         services.AddSingleton<ObsChatStore>();
         services.AddSingleton<ObsIntegrationStore>();
+        services.AddSingleton<UpdateStore>();
         services.AddSingleton<OnboardingChecklist>();
         return services;
     }

--- a/PoproshaykaBot.Core/Settings/Stores/UpdateStore.cs
+++ b/PoproshaykaBot.Core/Settings/Stores/UpdateStore.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure;
+using PoproshaykaBot.Core.Infrastructure.Persistence;
+using PoproshaykaBot.Core.Settings.Update;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Settings.Stores;
+
+public sealed class UpdateStore
+{
+    private readonly ILogger<UpdateStore>? _logger;
+    private readonly string _filePath;
+    private readonly object _syncLock = new();
+
+    private UpdateSettings _state;
+
+    public UpdateStore(ILogger<UpdateStore>? logger = null, string? filePath = null)
+    {
+        _logger = logger;
+        _filePath = filePath ?? AppPaths.SettingsFile("update.json");
+        _state = ReadFile();
+
+        _logger?.LogDebug("UpdateStore инициализирован из {FilePath}", _filePath);
+    }
+
+    public UpdateSettings Load()
+    {
+        lock (_syncLock)
+        {
+            return JsonStoreClone.DeepClone(_state);
+        }
+    }
+
+    public void Save(UpdateSettings value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        lock (_syncLock)
+        {
+            _state = JsonStoreClone.DeepClone(value);
+            var json = JsonSerializer.Serialize(_state, JsonStoreOptions.Default);
+            AtomicFile.Save(_filePath, json, _logger);
+
+            _logger?.LogInformation("UpdateStore: настройки обновления сохранены в {FilePath}", _filePath);
+        }
+    }
+
+    private UpdateSettings ReadFile()
+    {
+        if (!File.Exists(_filePath))
+        {
+            _logger?.LogDebug("UpdateStore: файл {FilePath} не найден, используются дефолты", _filePath);
+            return new();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize<UpdateSettings>(json, JsonStoreOptions.Default) ?? new();
+        }
+        catch (Exception exception)
+        {
+            _logger?.LogError(exception, "Ошибка чтения {FilePath}, применяются дефолты", _filePath);
+            JsonStoreBackup.CreateBackup(_filePath, "invalid", _logger);
+            return new();
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Settings/Update/UpdateApplyMode.cs
+++ b/PoproshaykaBot.Core/Settings/Update/UpdateApplyMode.cs
@@ -1,0 +1,7 @@
+﻿namespace PoproshaykaBot.Core.Settings.Update;
+
+public enum UpdateApplyMode
+{
+    NotifyAndConfirm = 0,
+    SilentOnExit = 1,
+}

--- a/PoproshaykaBot.Core/Settings/Update/UpdateSettings.cs
+++ b/PoproshaykaBot.Core/Settings/Update/UpdateSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace PoproshaykaBot.Core.Settings.Update;
+
+public sealed class UpdateSettings
+{
+    public bool AutoCheckEnabled { get; set; } = true;
+
+    public bool AllowFrameworkDependentUpdate { get; set; }
+
+    public string? RepositoryOverride { get; set; }
+
+    public int CheckIntervalHours { get; set; } = 6;
+
+    public string? SkippedVersion { get; set; }
+
+    public DateTimeOffset? LastCheckUtc { get; set; }
+
+    public UpdateApplyMode ApplyMode { get; set; } = UpdateApplyMode.NotifyAndConfirm;
+}

--- a/PoproshaykaBot.Core/Twitch/Auth/WebView2UserDataFolders.cs
+++ b/PoproshaykaBot.Core/Twitch/Auth/WebView2UserDataFolders.cs
@@ -5,10 +5,16 @@ namespace PoproshaykaBot.Core.Twitch.Auth;
 public static class WebView2UserDataFolders
 {
     private const string RootFolderName = "WebView2";
+    private const string OverlayPreviewSegment = "overlay-preview";
 
     public static string Resolve(TwitchOAuthRole role)
     {
         return AppPaths.Combine(RootFolderName, RoleSegment(role));
+    }
+
+    public static string ResolveOverlayPreview()
+    {
+        return AppPaths.Combine(RootFolderName, OverlayPreviewSegment);
     }
 
     private static string RoleSegment(TwitchOAuthRole role)

--- a/PoproshaykaBot.Core/Twitch/Chat/ChatIngestionService.cs
+++ b/PoproshaykaBot.Core/Twitch/Chat/ChatIngestionService.cs
@@ -144,7 +144,8 @@ public sealed class ChatIngestionService(
 
         try
         {
-            var chatMessage = EventSubChatMessageMapper.Map(args.Payload);
+            var botId = await botUserIdProvider.GetAsync(ct);
+            var chatMessage = EventSubChatMessageMapper.Map(args.Payload, botId);
             var timestamp = new DateTimeOffset(args.MessageTimestamp, TimeSpan.Zero);
             await eventBus.PublishAsync(new RawChatMessageReceived(chatMessage, timestamp), ct);
         }

--- a/PoproshaykaBot.Core/Twitch/Chat/EventSubChatMessageMapper.cs
+++ b/PoproshaykaBot.Core/Twitch/Chat/EventSubChatMessageMapper.cs
@@ -5,7 +5,7 @@ namespace PoproshaykaBot.Core.Twitch.Chat;
 
 public static class EventSubChatMessageMapper
 {
-    public static ChatMessage Map(JsonElement payload)
+    public static ChatMessage Map(JsonElement payload, string? botUserId = null)
     {
         if (!payload.TryGetProperty("event", out var evt))
         {
@@ -26,6 +26,10 @@ public static class EventSubChatMessageMapper
         var (badges, isBroadcaster, isModerator, isVip, isSubscriber) = ExtractBadges(evt);
         var emotes = ExtractEmotes(evt);
 
+        var isBot = !string.IsNullOrEmpty(botUserId)
+                    && !string.IsNullOrEmpty(userId)
+                    && string.Equals(userId, botUserId, StringComparison.Ordinal);
+
         return new(channel,
             messageId,
             userId,
@@ -37,7 +41,8 @@ public static class EventSubChatMessageMapper
             isBroadcaster,
             isModerator,
             isVip,
-            isSubscriber);
+            isSubscriber,
+            isBot);
     }
 
     private static (IReadOnlyList<(string SetId, string BadgeId)> Badges,

--- a/PoproshaykaBot.Core/Update/GitHubReleaseClient.cs
+++ b/PoproshaykaBot.Core/Update/GitHubReleaseClient.cs
@@ -1,0 +1,173 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class GitHubReleaseClient(
+    IHttpClientFactory httpClientFactory,
+    IUpdateRepositoryProvider repository,
+    ILogger<GitHubReleaseClient> logger)
+    : IGitHubReleaseClient
+{
+    public const string HttpClientName = "GitHubReleases";
+
+    private const int DownloadBufferSize = 81920;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<ReleaseInfo?> GetLatestReleaseAsync(CancellationToken cancellationToken)
+    {
+        using var client = httpClientFactory.CreateClient(HttpClientName);
+
+        var latestReleasePath = $"repos/{repository.Slug}/releases/latest";
+
+        using var response = await client
+            .GetAsync(latestReleasePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning("GitHub вернул статус {Status} при запросе последнего релиза", (int)response.StatusCode);
+            return null;
+        }
+
+        await using var stream = await response.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var dto = await JsonSerializer
+            .DeserializeAsync<ReleaseDto>(stream, JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (dto?.TagName is null)
+        {
+            return null;
+        }
+
+        var assets = (dto.Assets ?? [])
+            .Where(asset => asset is { Name: not null, BrowserDownloadUrl: not null })
+            .Select(asset => new ReleaseAsset(asset.Name!,
+                asset.BrowserDownloadUrl!,
+                asset.Size,
+                asset.ContentType ?? string.Empty))
+            .ToArray();
+
+        return new(dto.TagName,
+            dto.HtmlUrl ?? string.Empty,
+            dto.Body ?? string.Empty,
+            dto.Prerelease,
+            dto.Draft,
+            assets);
+    }
+
+    public async Task<string> DownloadTextAsync(string url, CancellationToken cancellationToken)
+    {
+        using var client = httpClientFactory.CreateClient(HttpClientName);
+
+        using var response = await client
+            .GetAsync(url, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content
+            .ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task DownloadFileAsync(
+        string url,
+        string destinationPath,
+        IProgress<int>? progress,
+        CancellationToken cancellationToken)
+    {
+        using var client = httpClientFactory.CreateClient(HttpClientName);
+
+        using var response = await client
+            .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength ?? -1L;
+
+        await using var source = await response.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await using var destination = new FileStream(destinationPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            DownloadBufferSize,
+            true);
+
+        var buffer = new byte[DownloadBufferSize];
+        long received = 0;
+        var lastReportedPercent = -1;
+        int read;
+
+        while ((read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            await destination
+                .WriteAsync(buffer.AsMemory(0, read), cancellationToken)
+                .ConfigureAwait(false);
+
+            received += read;
+
+            if (progress is null || totalBytes <= 0)
+            {
+                continue;
+            }
+
+            var percent = (int)(received * 100 / totalBytes);
+            if (percent == lastReportedPercent)
+            {
+                continue;
+            }
+
+            lastReportedPercent = percent;
+            progress.Report(percent);
+        }
+    }
+
+    private sealed record ReleaseDto
+    {
+        [JsonPropertyName("tag_name")]
+        public string? TagName { get; init; }
+
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; init; }
+
+        [JsonPropertyName("body")]
+        public string? Body { get; init; }
+
+        [JsonPropertyName("prerelease")]
+        public bool Prerelease { get; init; }
+
+        [JsonPropertyName("draft")]
+        public bool Draft { get; init; }
+
+        [JsonPropertyName("assets")]
+        public AssetDto[]? Assets { get; init; }
+    }
+
+    private sealed record AssetDto
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; init; }
+
+        [JsonPropertyName("browser_download_url")]
+        public string? BrowserDownloadUrl { get; init; }
+
+        [JsonPropertyName("size")]
+        public long Size { get; init; }
+
+        [JsonPropertyName("content_type")]
+        public string? ContentType { get; init; }
+    }
+}

--- a/PoproshaykaBot.Core/Update/IGitHubReleaseClient.cs
+++ b/PoproshaykaBot.Core/Update/IGitHubReleaseClient.cs
@@ -1,0 +1,10 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public interface IGitHubReleaseClient
+{
+    Task<ReleaseInfo?> GetLatestReleaseAsync(CancellationToken cancellationToken);
+
+    Task<string> DownloadTextAsync(string url, CancellationToken cancellationToken);
+
+    Task DownloadFileAsync(string url, string destinationPath, IProgress<int>? progress, CancellationToken cancellationToken);
+}

--- a/PoproshaykaBot.Core/Update/IUpdateCoordinator.cs
+++ b/PoproshaykaBot.Core/Update/IUpdateCoordinator.cs
@@ -1,0 +1,22 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public interface IUpdateCoordinator
+{
+    UpdateKind Kind { get; }
+
+    bool IsUpdatable { get; }
+
+    string DefaultRepositorySlug { get; }
+
+    Version CurrentVersion { get; }
+
+    UpdateCandidate? LatestCandidate { get; }
+
+    bool HasPreparedUpdate { get; }
+
+    Task<UpdateCandidate?> CheckNowAsync(CancellationToken cancellationToken);
+
+    Task PrepareAsync(UpdateCandidate candidate, IProgress<int>? progress, CancellationToken cancellationToken);
+
+    void SkipVersion(string version);
+}

--- a/PoproshaykaBot.Core/Update/IUpdateEnvironment.cs
+++ b/PoproshaykaBot.Core/Update/IUpdateEnvironment.cs
@@ -1,0 +1,18 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public interface IUpdateEnvironment
+{
+    UpdateKind Kind { get; }
+
+    string RepositorySlug { get; }
+
+    Version CurrentVersion { get; }
+
+    int RuntimeMajor { get; }
+
+    string ArchitectureMoniker { get; }
+
+    string CurrentExecutablePath { get; }
+
+    string StagingDirectory { get; }
+}

--- a/PoproshaykaBot.Core/Update/IUpdateInstaller.cs
+++ b/PoproshaykaBot.Core/Update/IUpdateInstaller.cs
@@ -1,0 +1,8 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public interface IUpdateInstaller
+{
+    Task PrepareAsync(UpdateCandidate candidate, IProgress<int>? progress, CancellationToken cancellationToken);
+
+    PendingUpdate? ReadPending();
+}

--- a/PoproshaykaBot.Core/Update/IUpdateRepositoryProvider.cs
+++ b/PoproshaykaBot.Core/Update/IUpdateRepositoryProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public interface IUpdateRepositoryProvider
+{
+    string DefaultSlug { get; }
+
+    string Slug { get; }
+}

--- a/PoproshaykaBot.Core/Update/PendingUpdate.cs
+++ b/PoproshaykaBot.Core/Update/PendingUpdate.cs
@@ -1,0 +1,7 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed record PendingUpdate(
+    string Version,
+    string StagedExecutablePath,
+    string TargetExecutablePath,
+    string Sha256);

--- a/PoproshaykaBot.Core/Update/ReleaseAsset.cs
+++ b/PoproshaykaBot.Core/Update/ReleaseAsset.cs
@@ -1,0 +1,3 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed record ReleaseAsset(string Name, string DownloadUrl, long Size, string ContentType);

--- a/PoproshaykaBot.Core/Update/ReleaseInfo.cs
+++ b/PoproshaykaBot.Core/Update/ReleaseInfo.cs
@@ -1,0 +1,9 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed record ReleaseInfo(
+    string TagName,
+    string HtmlUrl,
+    string Body,
+    bool Prerelease,
+    bool Draft,
+    IReadOnlyList<ReleaseAsset> Assets);

--- a/PoproshaykaBot.Core/Update/ReleaseInfo.cs
+++ b/PoproshaykaBot.Core/Update/ReleaseInfo.cs
@@ -6,4 +6,10 @@ public sealed record ReleaseInfo(
     string Body,
     bool Prerelease,
     bool Draft,
-    IReadOnlyList<ReleaseAsset> Assets);
+    IReadOnlyList<ReleaseAsset> Assets)
+{
+    public bool HasAsset(string name)
+    {
+        return Assets.Any(asset => asset.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateApplier.cs
+++ b/PoproshaykaBot.Core/Update/UpdateApplier.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Settings.Stores;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateApplier
+{
+    public const string FinalizeArgument = "--finalize-update";
+
+    public static bool TryApplyPending(string stagingDirectory, string currentExecutablePath, ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(stagingDirectory);
+        ArgumentException.ThrowIfNullOrEmpty(currentExecutablePath);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var pendingPath = Path.Combine(stagingDirectory, UpdateInstaller.PendingFileName);
+
+        if (!File.Exists(pendingPath))
+        {
+            return false;
+        }
+
+        var pending = TryReadPending(pendingPath, logger);
+
+        if (pending is null)
+        {
+            return false;
+        }
+
+        if (!File.Exists(pending.StagedExecutablePath))
+        {
+            logger.LogWarning("Запланированное обновление недоступно, файл сборки отсутствует");
+            TryDelete(pendingPath, logger);
+            return false;
+        }
+
+        var plan = UpdateSwapPlanner.Plan(currentExecutablePath, pending.StagedExecutablePath);
+
+        if (!TrySwap(plan, pendingPath, logger))
+        {
+            return false;
+        }
+
+        logger.LogInformation("Версия {Version} установлена, перезапуск приложения", pending.Version);
+        Relaunch(plan.CurrentExecutable, logger);
+        return true;
+    }
+
+    private static PendingUpdate? TryReadPending(string pendingPath, ILogger logger)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<PendingUpdate>(File.ReadAllText(pendingPath),
+                JsonStoreOptions.Default);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось прочитать запланированное обновление {PendingPath}", pendingPath);
+            return null;
+        }
+    }
+
+    private static bool TrySwap(UpdateSwapPlan plan, string pendingPath, ILogger logger)
+    {
+        if (!TryRemoveStaleBackup(plan.BackupExecutable, logger))
+        {
+            return false;
+        }
+
+        try
+        {
+            File.Move(plan.CurrentExecutable, plan.BackupExecutable);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось переименовать текущий исполняемый файл — обновление отменено");
+            return false;
+        }
+
+        try
+        {
+            File.Move(plan.StagedExecutable, plan.CurrentExecutable);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось установить новую версию — выполняется откат");
+            Rollback(plan, logger);
+            TryDelete(pendingPath, logger);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryRemoveStaleBackup(string backupPath, ILogger logger)
+    {
+        if (!File.Exists(backupPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            File.Delete(backupPath);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Остался файл предыдущего обновления {BackupPath}, обновление отложено", backupPath);
+            return false;
+        }
+    }
+
+    private static void Rollback(UpdateSwapPlan plan, ILogger logger)
+    {
+        try
+        {
+            if (!File.Exists(plan.CurrentExecutable) && File.Exists(plan.BackupExecutable))
+            {
+                File.Move(plan.BackupExecutable, plan.CurrentExecutable);
+                logger.LogInformation("Откат выполнен: восстановлена предыдущая версия");
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось выполнить откат обновления");
+        }
+    }
+
+    private static void Relaunch(string executablePath, ILogger logger)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                UseShellExecute = true,
+                WorkingDirectory = Path.GetDirectoryName(executablePath) ?? string.Empty,
+            };
+
+            startInfo.ArgumentList.Add(FinalizeArgument);
+            using var process = Process.Start(startInfo);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось перезапустить приложение после обновления");
+        }
+    }
+
+    private static void TryDelete(string path, ILogger logger)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Не удалось удалить {Path}", path);
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateBackgroundService.cs
+++ b/PoproshaykaBot.Core/Update/UpdateBackgroundService.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure.Hosting;
+using PoproshaykaBot.Core.Settings.Stores;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateBackgroundService(
+    IUpdateCoordinator coordinator,
+    UpdateStore store,
+    TimeProvider timeProvider,
+    ILogger<UpdateBackgroundService> logger)
+    : IAppLifetimeComponent, IDisposable
+{
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(15);
+
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+
+    public string Name => "Проверка обновлений";
+
+    public int StartOrder => 50;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (coordinator.Kind == UpdateKind.Unsupported)
+        {
+            logger.LogInformation("Сборка не поддерживает автообновление — фоновая проверка отключена");
+            return Task.CompletedTask;
+        }
+
+        _cts?.Dispose();
+        _cts = new();
+        _loop = RunLoopAsync(_cts.Token);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        await _cts.CancelAsync().ConfigureAwait(false);
+
+        if (_loop is not null)
+        {
+            try
+            {
+                await _loop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // ожидаемо при остановке
+            }
+        }
+
+        _cts.Dispose();
+        _cts = null;
+        _loop = null;
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(InitialDelay, timeProvider, cancellationToken).ConfigureAwait(false);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var settings = store.Load();
+
+                if (settings.AutoCheckEnabled && coordinator.IsUpdatable)
+                {
+                    await coordinator.CheckNowAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                var hours = Math.Max(1, settings.CheckIntervalHours);
+                await Task.Delay(TimeSpan.FromHours(hours), timeProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // штатная остановка
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Фоновая проверка обновлений остановлена из-за ошибки");
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateCandidate.cs
+++ b/PoproshaykaBot.Core/Update/UpdateCandidate.cs
@@ -1,0 +1,3 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed record UpdateCandidate(Version Version, string TagName, ReleaseAsset Asset, string NotesUrl);

--- a/PoproshaykaBot.Core/Update/UpdateChecker.cs
+++ b/PoproshaykaBot.Core/Update/UpdateChecker.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateChecker(
+    IGitHubReleaseClient client,
+    IUpdateEnvironment environment,
+    ILogger<UpdateChecker> logger)
+{
+    public async Task<UpdateCandidate?> CheckAsync(string? skippedVersion, CancellationToken cancellationToken)
+    {
+        if (environment.Kind == UpdateKind.Unsupported)
+        {
+            return null;
+        }
+
+        var release = await client.GetLatestReleaseAsync(cancellationToken).ConfigureAwait(false);
+
+        if (release?.Draft != false || release.Prerelease)
+        {
+            return null;
+        }
+
+        if (!UpdateVersioning.TryParseTag(release.TagName, out var latest))
+        {
+            logger.LogWarning("Не удалось разобрать версию из тега релиза '{Tag}'", release.TagName);
+            return null;
+        }
+
+        if (!UpdateVersioning.IsNewer(latest, environment.CurrentVersion))
+        {
+            logger.LogDebug("Установлена актуальная версия {Current} (последняя {Latest})",
+                environment.CurrentVersion, latest);
+
+            return null;
+        }
+
+        var latestText = latest.ToString();
+
+        if (skippedVersion is not null && string.Equals(skippedVersion, latestText, StringComparison.Ordinal))
+        {
+            logger.LogInformation("Версия {Latest} пропущена пользователем", latestText);
+            return null;
+        }
+
+        var asset = UpdateVersioning.SelectAsset(release, environment.ArchitectureMoniker, environment.Kind);
+
+        if (asset is null)
+        {
+            logger.LogWarning("В релизе {Tag} нет сборки {Kind} для архитектуры {Arch}",
+                release.TagName, environment.Kind, environment.ArchitectureMoniker);
+
+            return null;
+        }
+
+        logger.LogInformation("Доступно обновление: {Latest} (текущая {Current})",
+            latestText, environment.CurrentVersion);
+
+        return new(latest, release.TagName, asset, release.HtmlUrl);
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateChecker.cs
+++ b/PoproshaykaBot.Core/Update/UpdateChecker.cs
@@ -53,9 +53,46 @@ public sealed class UpdateChecker(
             return null;
         }
 
+        if (!HasRequiredVerificationAssets(release))
+        {
+            return null;
+        }
+
         logger.LogInformation("Доступно обновление: {Latest} (текущая {Current})",
             latestText, environment.CurrentVersion);
 
         return new(latest, release.TagName, asset, release.HtmlUrl);
+    }
+
+    private bool HasRequiredVerificationAssets(ReleaseInfo release)
+    {
+        var checksumsName = UpdateVersioning.ChecksumsAssetName(environment.ArchitectureMoniker);
+
+        if (!release.HasAsset(checksumsName))
+        {
+            logger.LogWarning("Релиз {Tag} не содержит файл контрольных сумм {Asset}, автоматическое обновление невозможно. "
+                              + "Обновите программу вручную: {Url}",
+                release.TagName, checksumsName, release.HtmlUrl);
+
+            return false;
+        }
+
+        if (environment.Kind != UpdateKind.FrameworkDependent)
+        {
+            return true;
+        }
+
+        var runtimeName = UpdateVersioning.RuntimeAssetName(environment.ArchitectureMoniker);
+
+        if (!release.HasAsset(runtimeName))
+        {
+            logger.LogWarning("Релиз {Tag} не содержит файл {Asset} для проверки совместимости .NET, "
+                              + "автоматическое обновление невозможно. Обновите программу вручную: {Url}",
+                release.TagName, runtimeName, release.HtmlUrl);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/PoproshaykaBot.Core/Update/UpdateCoordinator.cs
+++ b/PoproshaykaBot.Core/Update/UpdateCoordinator.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure.Events;
+using PoproshaykaBot.Core.Infrastructure.Events.Update;
+using PoproshaykaBot.Core.Settings.Stores;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateCoordinator(
+    UpdateChecker checker,
+    IUpdateInstaller installer,
+    UpdateStore store,
+    IEventBus eventBus,
+    IUpdateEnvironment environment,
+    ILogger<UpdateCoordinator> logger)
+    : IUpdateCoordinator
+{
+    private readonly object _syncLock = new();
+
+    private UpdateCandidate? _latestCandidate;
+
+    public UpdateKind Kind => environment.Kind;
+
+    public bool IsUpdatable => environment.Kind switch
+    {
+        UpdateKind.Portable => true,
+        UpdateKind.FrameworkDependent => store.Load().AllowFrameworkDependentUpdate,
+        _ => false,
+    };
+
+    public string DefaultRepositorySlug => environment.RepositorySlug;
+
+    public Version CurrentVersion => environment.CurrentVersion;
+
+    public UpdateCandidate? LatestCandidate
+    {
+        get
+        {
+            lock (_syncLock)
+            {
+                return _latestCandidate;
+            }
+        }
+    }
+
+    public bool HasPreparedUpdate => installer.ReadPending() is not null;
+
+    public async Task<UpdateCandidate?> CheckNowAsync(CancellationToken cancellationToken)
+    {
+        var settings = store.Load();
+
+        UpdateCandidate? candidate;
+
+        try
+        {
+            candidate = await checker.CheckAsync(settings.SkippedVersion, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(exception, "Не удалось проверить наличие обновлений");
+            return null;
+        }
+
+        settings.LastCheckUtc = DateTimeOffset.UtcNow;
+        store.Save(settings);
+
+        if (candidate is null)
+        {
+            return null;
+        }
+
+        lock (_syncLock)
+        {
+            _latestCandidate = candidate;
+        }
+
+        await eventBus
+            .PublishAsync(new UpdateAvailable(candidate.Version.ToString(), candidate.NotesUrl), cancellationToken)
+            .ConfigureAwait(false);
+
+        return candidate;
+    }
+
+    public Task PrepareAsync(UpdateCandidate candidate, IProgress<int>? progress, CancellationToken cancellationToken)
+    {
+        return installer.PrepareAsync(candidate, progress, cancellationToken);
+    }
+
+    public void SkipVersion(string version)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(version);
+
+        var settings = store.Load();
+        settings.SkippedVersion = version;
+        store.Save(settings);
+
+        lock (_syncLock)
+        {
+            if (_latestCandidate is not null
+                && string.Equals(_latestCandidate.Version.ToString(), version, StringComparison.Ordinal))
+            {
+                _latestCandidate = null;
+            }
+        }
+
+        logger.LogInformation("Версия {Version} помечена как пропущенная", version);
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateEnvironment.cs
+++ b/PoproshaykaBot.Core/Update/UpdateEnvironment.cs
@@ -1,0 +1,98 @@
+﻿using PoproshaykaBot.Core.Infrastructure;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateEnvironment : IUpdateEnvironment
+{
+    private const string UpdatableMetadataKey = "UpdatableBuild";
+    private const string RepositoryMetadataKey = "GitHubRepository";
+    private const string DefaultRepositorySlug = "MaxNagibator/PoproshaykaBot";
+
+    public UpdateKind Kind { get; } = ResolveKind();
+
+    public string RepositorySlug { get; } = ResolveRepositorySlug();
+
+    public Version CurrentVersion { get; } = ResolveCurrentVersion();
+
+    public int RuntimeMajor { get; } = ResolveRuntimeMajor();
+
+    public string ArchitectureMoniker { get; } = ResolveArchitectureMoniker();
+
+    public string CurrentExecutablePath => Environment.ProcessPath
+                                           ?? throw new UpdateException("Не удалось определить путь к исполняемому файлу.");
+
+    public string StagingDirectory => UpdatePaths.StagingDirectory(CurrentExecutablePath);
+
+    private static UpdateKind ResolveKind()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(UpdateEnvironment).Assembly;
+
+        var isUpdatableBuild = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Any(a => string.Equals(a.Key, UpdatableMetadataKey, StringComparison.OrdinalIgnoreCase)
+                      && string.Equals(a.Value, "true", StringComparison.OrdinalIgnoreCase));
+
+        if (!isUpdatableBuild)
+        {
+            return UpdateKind.Unsupported;
+        }
+
+        return AppPaths.IsPortable ? UpdateKind.Portable : UpdateKind.FrameworkDependent;
+    }
+
+    private static string ResolveRepositorySlug()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(UpdateEnvironment).Assembly;
+
+        var slug = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, RepositoryMetadataKey, StringComparison.OrdinalIgnoreCase))
+            ?
+            .Value;
+
+        return string.IsNullOrWhiteSpace(slug) ? DefaultRepositorySlug : slug.Trim();
+    }
+
+    private static Version ResolveCurrentVersion()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(UpdateEnvironment).Assembly;
+
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?
+            .InformationalVersion;
+
+        if (UpdateVersioning.TryParseTag(informational, out var fromInformational))
+        {
+            return fromInformational;
+        }
+
+        return assembly.GetName().Version ?? new Version(0, 0);
+    }
+
+    private static int ResolveRuntimeMajor()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(UpdateEnvironment).Assembly;
+
+        var frameworkName = assembly
+            .GetCustomAttribute<TargetFrameworkAttribute>()
+            ?
+            .FrameworkName;
+
+        return UpdateRuntime.ParseMajor(frameworkName) ?? Environment.Version.Major;
+    }
+
+    private static string ResolveArchitectureMoniker()
+    {
+        return RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            var other => other.ToString().ToLowerInvariant(),
+        };
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateException.cs
+++ b/PoproshaykaBot.Core/Update/UpdateException.cs
@@ -1,0 +1,18 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateException : Exception
+{
+    public UpdateException()
+    {
+    }
+
+    public UpdateException(string message)
+        : base(message)
+    {
+    }
+
+    public UpdateException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateFinalizer.cs
+++ b/PoproshaykaBot.Core/Update/UpdateFinalizer.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateFinalizer
+{
+    private const int MaxAttempts = 12;
+    private const int RetryDelayMs = 300;
+
+    public static void Run(string stagingDirectory, string currentExecutablePath, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var backupPath = currentExecutablePath + UpdateSwapPlanner.BackupSuffix;
+
+        DeleteWithRetry(() => File.Exists(backupPath),
+            () => File.Delete(backupPath),
+            backupPath,
+            logger);
+
+        DeleteWithRetry(() => Directory.Exists(stagingDirectory),
+            () => Directory.Delete(stagingDirectory, true),
+            stagingDirectory,
+            logger);
+    }
+
+    private static void DeleteWithRetry(Func<bool> exists, Action delete, string target, ILogger logger)
+    {
+        if (!exists())
+        {
+            return;
+        }
+
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                delete();
+                logger.LogInformation("Очищен временный объект обновления {Target}", target);
+                return;
+            }
+            catch (Exception exception)
+            {
+                if (attempt == MaxAttempts)
+                {
+                    logger.LogWarning(exception,
+                        "Не удалось удалить {Target} после обновления, будет очищено при следующем запуске",
+                        target);
+
+                    return;
+                }
+
+                Thread.Sleep(RetryDelayMs);
+            }
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateInstaller.cs
+++ b/PoproshaykaBot.Core/Update/UpdateInstaller.cs
@@ -1,0 +1,242 @@
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Infrastructure.Persistence;
+using PoproshaykaBot.Core.Settings.Stores;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateInstaller(
+    IGitHubReleaseClient client,
+    IUpdateEnvironment environment,
+    ILogger<UpdateInstaller> logger)
+    : IUpdateInstaller
+{
+    public const string PendingFileName = "apply-update.json";
+
+    public async Task PrepareAsync(
+        UpdateCandidate candidate,
+        IProgress<int>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        EnsureExecutableDirectoryWritable();
+
+        await EnsureRuntimeCompatibleAsync(candidate, cancellationToken).ConfigureAwait(false);
+
+        var stagingDirectory = environment.StagingDirectory;
+        Directory.CreateDirectory(stagingDirectory);
+
+        var partPath = Path.Combine(stagingDirectory, candidate.Asset.Name + ".part");
+        var stagedPath = Path.Combine(stagingDirectory, candidate.Asset.Name);
+
+        logger.LogInformation("Загрузка обновления {Version} из {Url}",
+            candidate.Version, candidate.Asset.DownloadUrl);
+
+        await client
+            .DownloadFileAsync(candidate.Asset.DownloadUrl, partPath, progress, cancellationToken)
+            .ConfigureAwait(false);
+
+        var expectedHash = await ResolveExpectedHashAsync(candidate, cancellationToken).ConfigureAwait(false);
+        var actualHash = await ComputeSha256Async(partPath, cancellationToken).ConfigureAwait(false);
+
+        if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+        {
+            TryDelete(partPath);
+            logger.LogError("Контрольная сумма обновления не совпала. Ожидалось {Expected}, получено {Actual}",
+                expectedHash, actualHash);
+
+            throw new UpdateException("Контрольная сумма загруженного обновления не совпала. Файл повреждён или подменён.");
+        }
+
+        if (File.Exists(stagedPath))
+        {
+            File.Delete(stagedPath);
+        }
+
+        File.Move(partPath, stagedPath);
+
+        var pending = new PendingUpdate(candidate.Version.ToString(),
+            stagedPath,
+            environment.CurrentExecutablePath,
+            actualHash);
+
+        var json = JsonSerializer.Serialize(pending, JsonStoreOptions.Default);
+        AtomicFile.Save(Path.Combine(stagingDirectory, PendingFileName), json, logger);
+
+        logger.LogInformation("Обновление {Version} подготовлено и проверено", candidate.Version);
+    }
+
+    public PendingUpdate? ReadPending()
+    {
+        var pendingPath = Path.Combine(environment.StagingDirectory, PendingFileName);
+
+        if (!File.Exists(pendingPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(pendingPath);
+            var pending = JsonSerializer.Deserialize<PendingUpdate>(json, JsonStoreOptions.Default);
+
+            if (pending is null || !File.Exists(pending.StagedExecutablePath))
+            {
+                return null;
+            }
+
+            return pending;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Не удалось прочитать {PendingPath}", pendingPath);
+            return null;
+        }
+    }
+
+    private static string BuildChecksumsUrl(string assetUrl, string architectureMoniker)
+    {
+        return BuildSiblingUrl(assetUrl, "SHA256SUMS-" + architectureMoniker + ".txt");
+    }
+
+    private static string BuildSiblingUrl(string assetUrl, string fileName)
+    {
+        var lastSlash = assetUrl.LastIndexOf('/');
+
+        if (lastSlash < 0)
+        {
+            throw new UpdateException("Некорректный URL ресурса релиза.");
+        }
+
+        return assetUrl[..(lastSlash + 1)] + fileName;
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken cancellationToken)
+    {
+        using var stream = new FileStream(path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            81920,
+            true);
+
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false);
+        return Convert.ToHexString(hash);
+    }
+
+    private async Task<string> ResolveExpectedHashAsync(
+        UpdateCandidate candidate,
+        CancellationToken cancellationToken)
+    {
+        var checksumsUrl = BuildChecksumsUrl(candidate.Asset.DownloadUrl, environment.ArchitectureMoniker);
+
+        string checksums;
+
+        try
+        {
+            checksums = await client.DownloadTextAsync(checksumsUrl, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new UpdateException("Не удалось загрузить файл контрольных сумм релиза. Обновление прервано.", exception);
+        }
+
+        foreach (var line in checksums.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = line.Split((char[]?)null, 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (parts[1].EndsWith(candidate.Asset.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return parts[0];
+            }
+        }
+
+        throw new UpdateException("В файле контрольных сумм нет записи для скачанной сборки. Обновление прервано.");
+    }
+
+    private async Task EnsureRuntimeCompatibleAsync(UpdateCandidate candidate, CancellationToken cancellationToken)
+    {
+        if (environment.Kind != UpdateKind.FrameworkDependent)
+        {
+            return;
+        }
+
+        var url = BuildSiblingUrl(candidate.Asset.DownloadUrl, "RUNTIME-" + environment.ArchitectureMoniker + ".txt");
+
+        string runtimeText;
+
+        try
+        {
+            runtimeText = await client.DownloadTextAsync(url, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new UpdateException("Не удалось проверить совместимость версии .NET для обновления. "
+                                      + "Скачайте новую версию вручную со страницы релизов.", exception);
+        }
+
+        var requiredMajor = UpdateRuntime.ParseMajor(runtimeText.Trim());
+
+        if (requiredMajor is null)
+        {
+            logger.LogWarning("Не удалось разобрать требуемую версию .NET из '{Value}', проверка пропущена", runtimeText);
+            return;
+        }
+
+        if (requiredMajor.Value != environment.RuntimeMajor)
+        {
+            throw new UpdateException($"Обновление требует .NET {requiredMajor.Value}, а текущая сборка работает на .NET {environment.RuntimeMajor}. "
+                                      + "Установите нужный .NET Desktop Runtime и скачайте новую версию вручную со страницы релизов.");
+        }
+    }
+
+    private void EnsureExecutableDirectoryWritable()
+    {
+        var directory = Path.GetDirectoryName(environment.CurrentExecutablePath);
+
+        if (string.IsNullOrEmpty(directory))
+        {
+            throw new UpdateException("Не удалось определить каталог исполняемого файла.");
+        }
+
+        var probePath = Path.Combine(directory, ".update-write-probe-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            File.WriteAllText(probePath, "probe");
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new UpdateException("Нет прав на запись в каталог приложения. Переместите программу в папку пользователя "
+                                      + "(например, в Документы или на рабочий стол) или скачайте обновление вручную.", exception);
+        }
+        finally
+        {
+            TryDelete(probePath);
+        }
+    }
+
+    private void TryDelete(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Не удалось удалить временный файл {Path}", path);
+        }
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateInstaller.cs
+++ b/PoproshaykaBot.Core/Update/UpdateInstaller.cs
@@ -98,7 +98,7 @@ public sealed class UpdateInstaller(
 
     private static string BuildChecksumsUrl(string assetUrl, string architectureMoniker)
     {
-        return BuildSiblingUrl(assetUrl, "SHA256SUMS-" + architectureMoniker + ".txt");
+        return BuildSiblingUrl(assetUrl, UpdateVersioning.ChecksumsAssetName(architectureMoniker));
     }
 
     private static string BuildSiblingUrl(string assetUrl, string fileName)
@@ -168,7 +168,8 @@ public sealed class UpdateInstaller(
             return;
         }
 
-        var url = BuildSiblingUrl(candidate.Asset.DownloadUrl, "RUNTIME-" + environment.ArchitectureMoniker + ".txt");
+        var url = BuildSiblingUrl(candidate.Asset.DownloadUrl,
+            UpdateVersioning.RuntimeAssetName(environment.ArchitectureMoniker));
 
         string runtimeText;
 

--- a/PoproshaykaBot.Core/Update/UpdateKind.cs
+++ b/PoproshaykaBot.Core/Update/UpdateKind.cs
@@ -1,0 +1,8 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public enum UpdateKind
+{
+    Unsupported = 0,
+    Portable = 1,
+    FrameworkDependent = 2,
+}

--- a/PoproshaykaBot.Core/Update/UpdatePaths.cs
+++ b/PoproshaykaBot.Core/Update/UpdatePaths.cs
@@ -1,0 +1,16 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public static class UpdatePaths
+{
+    public const string StagingFolderName = "update";
+
+    public static string StagingDirectory(string executablePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(executablePath);
+
+        var directory = Path.GetDirectoryName(executablePath)
+                        ?? throw new UpdateException("Не удалось определить каталог исполняемого файла.");
+
+        return Path.Combine(directory, StagingFolderName);
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateRepository.cs
+++ b/PoproshaykaBot.Core/Update/UpdateRepository.cs
@@ -1,0 +1,53 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateRepository
+{
+    private const int MaxPartLength = 100;
+
+    public static bool IsValidSlug(string? slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            return false;
+        }
+
+        var separator = slug.IndexOf('/', StringComparison.Ordinal);
+
+        if (separator <= 0 || separator != slug.LastIndexOf('/'))
+        {
+            return false;
+        }
+
+        var owner = slug.AsSpan(0, separator);
+        var repo = slug.AsSpan(separator + 1);
+
+        return IsValidPart(owner) && IsValidPart(repo);
+    }
+
+    public static string Resolve(string? overrideSlug, string defaultSlug)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultSlug);
+
+        var trimmed = overrideSlug?.Trim();
+
+        return IsValidSlug(trimmed) ? trimmed! : defaultSlug;
+    }
+
+    private static bool IsValidPart(ReadOnlySpan<char> part)
+    {
+        if (part.IsEmpty || part.Length > MaxPartLength || part.Contains("..", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var c in part)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('.' or '_' or '-'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateRepositoryProvider.cs
+++ b/PoproshaykaBot.Core/Update/UpdateRepositoryProvider.cs
@@ -1,0 +1,11 @@
+﻿using PoproshaykaBot.Core.Settings.Stores;
+
+namespace PoproshaykaBot.Core.Update;
+
+public sealed class UpdateRepositoryProvider(UpdateStore store, IUpdateEnvironment environment)
+    : IUpdateRepositoryProvider
+{
+    public string DefaultSlug => environment.RepositorySlug;
+
+    public string Slug => UpdateRepository.Resolve(store.Load().RepositoryOverride, environment.RepositorySlug);
+}

--- a/PoproshaykaBot.Core/Update/UpdateRuntime.cs
+++ b/PoproshaykaBot.Core/Update/UpdateRuntime.cs
@@ -1,0 +1,45 @@
+﻿using System.Globalization;
+
+namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateRuntime
+{
+    public static int? ParseMajor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+
+        var start = FindDigitsStart(trimmed, "Version=v");
+
+        if (start < 0)
+        {
+            start = FindDigitsStart(trimmed, "net");
+        }
+
+        if (start < 0 || start >= trimmed.Length || !char.IsAsciiDigit(trimmed[start]))
+        {
+            return null;
+        }
+
+        var end = start;
+
+        while (end < trimmed.Length && char.IsAsciiDigit(trimmed[end]))
+        {
+            end++;
+        }
+
+        return int.TryParse(trimmed.AsSpan(start, end - start), NumberStyles.Integer, CultureInfo.InvariantCulture, out var major)
+            ? major
+            : null;
+    }
+
+    private static int FindDigitsStart(string value, string marker)
+    {
+        var index = value.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        return index < 0 ? -1 : index + marker.Length;
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateServiceCollectionExtensions.cs
+++ b/PoproshaykaBot.Core/Update/UpdateServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using PoproshaykaBot.Core.Infrastructure.Hosting;
+
+namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateServiceCollectionExtensions
+{
+    public static IServiceCollection AddSelfUpdate(this IServiceCollection services)
+    {
+        services.AddHttpClient(GitHubReleaseClient.HttpClientName, client =>
+        {
+            client.BaseAddress = new("https://api.github.com/");
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("PoproshaykaBot");
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        });
+
+        services.AddSingleton<IUpdateEnvironment, UpdateEnvironment>();
+        services.AddSingleton<IUpdateRepositoryProvider, UpdateRepositoryProvider>();
+        services.AddSingleton<IGitHubReleaseClient, GitHubReleaseClient>();
+        services.AddSingleton<UpdateChecker>();
+        services.AddSingleton<IUpdateInstaller, UpdateInstaller>();
+        services.AddSingleton<IUpdateCoordinator, UpdateCoordinator>();
+        services.AddSingleton<IAppLifetimeComponent, UpdateBackgroundService>();
+
+        return services;
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateSwapPlan.cs
+++ b/PoproshaykaBot.Core/Update/UpdateSwapPlan.cs
@@ -1,0 +1,3 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public sealed record UpdateSwapPlan(string CurrentExecutable, string BackupExecutable, string StagedExecutable);

--- a/PoproshaykaBot.Core/Update/UpdateSwapPlanner.cs
+++ b/PoproshaykaBot.Core/Update/UpdateSwapPlanner.cs
@@ -1,0 +1,16 @@
+﻿namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateSwapPlanner
+{
+    public const string BackupSuffix = ".old";
+
+    public static UpdateSwapPlan Plan(string currentExecutable, string stagedExecutable)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(currentExecutable);
+        ArgumentException.ThrowIfNullOrEmpty(stagedExecutable);
+
+        return new(currentExecutable,
+            currentExecutable + BackupSuffix,
+            stagedExecutable);
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateVersioning.cs
+++ b/PoproshaykaBot.Core/Update/UpdateVersioning.cs
@@ -1,0 +1,82 @@
+﻿using System.Globalization;
+
+namespace PoproshaykaBot.Core.Update;
+
+public static class UpdateVersioning
+{
+    public static bool TryParseTag(string? raw, out Version version)
+    {
+        version = new(0, 0);
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        var trimmed = raw.Trim();
+
+        if (trimmed.StartsWith('v') || trimmed.StartsWith('V'))
+        {
+            trimmed = trimmed[1..];
+        }
+
+        var plusIndex = trimmed.IndexOf('+', StringComparison.Ordinal);
+
+        if (plusIndex > 0)
+        {
+            trimmed = trimmed[..plusIndex];
+        }
+
+        var dashIndex = trimmed.IndexOf('-', StringComparison.Ordinal);
+
+        if (dashIndex > 0)
+        {
+            trimmed = trimmed[..dashIndex];
+        }
+
+        return Version.TryParse(trimmed, out var parsed) && TryNormalize(parsed, out version);
+    }
+
+    public static string AssetSuffix(string architectureMoniker, UpdateKind kind)
+    {
+        return kind switch
+        {
+            UpdateKind.Portable => string.Create(CultureInfo.InvariantCulture, $"-{architectureMoniker}-portable.exe"),
+            UpdateKind.FrameworkDependent => string.Create(CultureInfo.InvariantCulture, $"-{architectureMoniker}.exe"),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Сборка не поддерживает автообновление."),
+        };
+    }
+
+    public static ReleaseAsset? SelectAsset(ReleaseInfo release, string architectureMoniker, UpdateKind kind)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+
+        if (kind is not (UpdateKind.Portable or UpdateKind.FrameworkDependent))
+        {
+            return null;
+        }
+
+        var suffix = AssetSuffix(architectureMoniker, kind);
+
+        return release.Assets.FirstOrDefault(asset =>
+            asset.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static bool IsNewer(Version candidate, Version current)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(current);
+
+        return candidate > current;
+    }
+
+    private static bool TryNormalize(Version source, out Version normalized)
+    {
+        normalized = new(Math.Max(source.Major, 0),
+            Math.Max(source.Minor, 0),
+            Math.Max(source.Build, 0),
+            Math.Max(source.Revision, 0));
+
+        return true;
+    }
+}

--- a/PoproshaykaBot.Core/Update/UpdateVersioning.cs
+++ b/PoproshaykaBot.Core/Update/UpdateVersioning.cs
@@ -47,6 +47,16 @@ public static class UpdateVersioning
         };
     }
 
+    public static string ChecksumsAssetName(string architectureMoniker)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"SHA256SUMS-{architectureMoniker}.txt");
+    }
+
+    public static string RuntimeAssetName(string architectureMoniker)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"RUNTIME-{architectureMoniker}.txt");
+    }
+
     public static ReleaseAsset? SelectAsset(ReleaseInfo release, string architectureMoniker, UpdateKind kind)
     {
         ArgumentNullException.ThrowIfNull(release);

--- a/PoproshaykaBot.WinForms/Forms/Onboarding/EmbeddedTwitchAuthDialog.cs
+++ b/PoproshaykaBot.WinForms/Forms/Onboarding/EmbeddedTwitchAuthDialog.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 using PoproshaykaBot.Core.Twitch.Auth;
+using PoproshaykaBot.WinForms.Infrastructure;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 using System.Diagnostics;
 
@@ -184,9 +185,8 @@ public partial class EmbeddedTwitchAuthDialog : Form
         try
         {
             var udf = WebView2UserDataFolders.Resolve(Role);
-            Directory.CreateDirectory(udf);
 
-            var environment = await CoreWebView2Environment.CreateAsync(null, udf);
+            var environment = await WebView2EnvironmentFactory.CreateAsync(udf, _logger);
             await _webView.EnsureCoreWebView2Async(environment);
 
             if (IsDisposed || Disposing)

--- a/PoproshaykaBot.WinForms/Forms/Onboarding/Pages/HealthCheckPage.cs
+++ b/PoproshaykaBot.WinForms/Forms/Onboarding/Pages/HealthCheckPage.cs
@@ -112,9 +112,7 @@ public sealed partial class HealthCheckPage : OnboardingPageBase
             return;
         }
 
-        var botUserId = _context.BotAccount.UserId;
-        if (string.IsNullOrWhiteSpace(botUserId)
-            || !string.Equals(@event.UserId, botUserId, StringComparison.Ordinal))
+        if (!@event.IsBot)
         {
             return;
         }

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsChatSettingsControl.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsChatSettingsControl.Designer.cs
@@ -127,6 +127,7 @@
             _firstTimeUserMessageAnimationLabel = new Label();
             _firstTimeUserMessageAnimationComboBox = new ComboBox();
             _firstTimeUserMessageAnimationResetButton = new Button();
+            _openAnimationsDemoButton = new Button();
             _mainTabControl.SuspendLayout();
 
 
@@ -817,6 +818,8 @@
             _animationsTableLayout.Controls.Add(_firstTimeUserMessageAnimationLabel, 0, 10);
             _animationsTableLayout.Controls.Add(_firstTimeUserMessageAnimationComboBox, 1, 10);
             _animationsTableLayout.Controls.Add(_firstTimeUserMessageAnimationResetButton, 2, 10);
+            _animationsTableLayout.Controls.Add(_openAnimationsDemoButton, 0, 11);
+            _animationsTableLayout.SetColumnSpan(_openAnimationsDemoButton, 3);
             _animationsTableLayout.Dock = DockStyle.Fill;
             _animationsTableLayout.Location = new Point(3, 3);
             _animationsTableLayout.Name = "_animationsTableLayout";
@@ -1440,8 +1443,20 @@
             _firstTimeUserMessageAnimationResetButton.UseVisualStyleBackColor = true;
             _firstTimeUserMessageAnimationResetButton.Click += OnFirstTimeUserMessageAnimationResetButtonClicked;
             //
+            // _openAnimationsDemoButton
+            //
+            _openAnimationsDemoButton.AutoSize = true;
+            _openAnimationsDemoButton.Anchor = AnchorStyles.Left;
+            _openAnimationsDemoButton.Margin = new Padding(0, 10, 0, 0);
+            _openAnimationsDemoButton.MinimumSize = new Size(220, 30);
+            _openAnimationsDemoButton.Name = "_openAnimationsDemoButton";
+            _openAnimationsDemoButton.TabIndex = 15;
+            _openAnimationsDemoButton.Text = "🎬 Открыть демо анимаций в браузере";
+            _openAnimationsDemoButton.UseVisualStyleBackColor = true;
+            _openAnimationsDemoButton.Click += OnOpenAnimationsDemoButtonClicked;
+            //
             // ObsChatSettingsControl
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             Controls.Add(_mainTabControl);
@@ -1577,5 +1592,6 @@
         private Label _firstTimeUserMessageAnimationLabel;
         private ComboBox _firstTimeUserMessageAnimationComboBox;
         private Button _firstTimeUserMessageAnimationResetButton;
+        private Button _openAnimationsDemoButton;
     }
 }

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsChatSettingsControl.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsChatSettingsControl.cs
@@ -1,5 +1,7 @@
 ﻿using Cyotek.Windows.Forms;
 using PoproshaykaBot.Core.Settings.Obs;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace PoproshaykaBot.WinForms.Forms.Settings;
 
@@ -8,6 +10,8 @@ public partial class ObsChatSettingsControl : UserControl
     private static readonly ObsChatSettings DefaultSettings = new();
 
     private readonly ErrorProvider _fontFamilyErrorProvider = new();
+
+    private int _httpServerPort;
 
     public ObsChatSettingsControl()
     {
@@ -20,8 +24,10 @@ public partial class ObsChatSettingsControl : UserControl
 
     public event EventHandler? SettingChanged;
 
-    public void LoadSettings(ObsChatSettings settings)
+    public void LoadSettings(ObsChatSettings settings, int httpServerPort)
     {
+        _httpServerPort = httpServerPort;
+
         _backgroundColorButton.BackColor = settings.BackgroundColor;
         _textColorButton.BackColor = settings.TextColor;
         _usernameColorButton.BackColor = settings.UsernameColor;
@@ -260,6 +266,37 @@ public partial class ObsChatSettingsControl : UserControl
     private void OnFirstTimeUserMessageAnimationResetButtonClicked(object sender, EventArgs e)
     {
         ResetAnimation(_firstTimeUserMessageAnimationComboBox, DefaultSettings.FirstTimeUserMessageAnimation, MessageAnimationType.EntryAnimations);
+    }
+
+    private void OnOpenAnimationsDemoButtonClicked(object sender, EventArgs e)
+    {
+        if (_httpServerPort <= 0)
+        {
+            MessageBox.Show(this,
+                "Не удалось определить порт HTTP-сервера. Проверьте настройки на вкладке «HTTP сервер».",
+                "Демо анимаций",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+
+            return;
+        }
+
+        var url = string.Format(CultureInfo.InvariantCulture,
+            "http://localhost:{0}/animations-demo",
+            _httpServerPort);
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception exception)
+        {
+            MessageBox.Show(this,
+                $"Не удалось открыть демо в браузере.\n\n{exception.Message}",
+                "Демо анимаций",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+        }
     }
 
     private void OnBackgroundColorButtonClicked(object sender, EventArgs e)

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
@@ -33,6 +33,7 @@ partial class ObsIntegrationSettingsControl
         _enabledCheckBox = new CheckBox();
         _autoConnectCheckBox = new CheckBox();
         _autoProvisionCheckBox = new CheckBox();
+        _refreshOnStreamStartCheckBox = new CheckBox();
         _syncSceneOnProfileCheckBox = new CheckBox();
         _syncProfileOnSceneCheckBox = new CheckBox();
         _formLayout = new TableLayoutPanel();
@@ -46,6 +47,8 @@ partial class ObsIntegrationSettingsControl
         _sceneComboBox = new ComboBox();
         _sourcesLabel = new Label();
         _sourcesCheckedListBox = new CheckedListBox();
+        _chatRefreshSourcesLabel = new Label();
+        _chatRefreshSourcesCheckedListBox = new CheckedListBox();
         _volumeMeterDelayLabel = new Label();
         _volumeMeterDelayNumeric = new NumericUpDown();
         _sourceNameLabel = new Label();
@@ -63,6 +66,7 @@ partial class ObsIntegrationSettingsControl
         _reconnectButton = new Button();
         _loadScenesButton = new Button();
         _provisionButton = new Button();
+        _refreshChatNowButton = new Button();
         _copyUrlButton = new Button();
         _hintToolTip = new ToolTip(components);
         _rootLayout.SuspendLayout();
@@ -82,26 +86,28 @@ partial class ObsIntegrationSettingsControl
         _rootLayout.Controls.Add(_enabledCheckBox, 0, 0);
         _rootLayout.Controls.Add(_autoConnectCheckBox, 0, 1);
         _rootLayout.Controls.Add(_autoProvisionCheckBox, 0, 2);
-        _rootLayout.Controls.Add(_syncSceneOnProfileCheckBox, 0, 3);
-        _rootLayout.Controls.Add(_syncProfileOnSceneCheckBox, 0, 4);
-        _rootLayout.Controls.Add(_formLayout, 0, 5);
-        _rootLayout.Controls.Add(_statusLabel, 0, 6);
-        _rootLayout.Controls.Add(_buttonPanel, 0, 7);
+        _rootLayout.Controls.Add(_refreshOnStreamStartCheckBox, 0, 3);
+        _rootLayout.Controls.Add(_syncSceneOnProfileCheckBox, 0, 4);
+        _rootLayout.Controls.Add(_syncProfileOnSceneCheckBox, 0, 5);
+        _rootLayout.Controls.Add(_formLayout, 0, 6);
+        _rootLayout.Controls.Add(_statusLabel, 0, 7);
+        _rootLayout.Controls.Add(_buttonPanel, 0, 8);
         _rootLayout.Dock = DockStyle.Fill;
         _rootLayout.Location = new Point(0, 0);
         _rootLayout.Name = "_rootLayout";
         _rootLayout.Padding = new Padding(4, 4, 4, 4);
-        _rootLayout.RowCount = 9;
+        _rootLayout.RowCount = 10;
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 398F));
+        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 488F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _rootLayout.Size = new Size(600, 614);
+        _rootLayout.Size = new Size(600, 732);
         _rootLayout.TabIndex = 0;
         //
         // _enabledCheckBox
@@ -140,14 +146,26 @@ partial class ObsIntegrationSettingsControl
         _autoProvisionCheckBox.UseVisualStyleBackColor = true;
         _autoProvisionCheckBox.CheckedChanged += OnSettingChanged;
         //
+        // _refreshOnStreamStartCheckBox
+        //
+        _refreshOnStreamStartCheckBox.AutoSize = true;
+        _refreshOnStreamStartCheckBox.Dock = DockStyle.Fill;
+        _refreshOnStreamStartCheckBox.Location = new Point(7, 91);
+        _refreshOnStreamStartCheckBox.Name = "_refreshOnStreamStartCheckBox";
+        _refreshOnStreamStartCheckBox.Size = new Size(586, 22);
+        _refreshOnStreamStartCheckBox.TabIndex = 3;
+        _refreshOnStreamStartCheckBox.Text = "Жёстко обновлять чат-источники при старте эфира в OBS";
+        _refreshOnStreamStartCheckBox.UseVisualStyleBackColor = true;
+        _refreshOnStreamStartCheckBox.CheckedChanged += OnSettingChanged;
+        //
         // _syncSceneOnProfileCheckBox
         //
         _syncSceneOnProfileCheckBox.AutoSize = true;
         _syncSceneOnProfileCheckBox.Dock = DockStyle.Fill;
-        _syncSceneOnProfileCheckBox.Location = new Point(7, 91);
+        _syncSceneOnProfileCheckBox.Location = new Point(7, 119);
         _syncSceneOnProfileCheckBox.Name = "_syncSceneOnProfileCheckBox";
         _syncSceneOnProfileCheckBox.Size = new Size(586, 22);
-        _syncSceneOnProfileCheckBox.TabIndex = 3;
+        _syncSceneOnProfileCheckBox.TabIndex = 4;
         _syncSceneOnProfileCheckBox.Text = "Переключать сцену OBS при смене профиля";
         _syncSceneOnProfileCheckBox.UseVisualStyleBackColor = true;
         _syncSceneOnProfileCheckBox.CheckedChanged += OnSettingChanged;
@@ -156,10 +174,10 @@ partial class ObsIntegrationSettingsControl
         //
         _syncProfileOnSceneCheckBox.AutoSize = true;
         _syncProfileOnSceneCheckBox.Dock = DockStyle.Fill;
-        _syncProfileOnSceneCheckBox.Location = new Point(7, 119);
+        _syncProfileOnSceneCheckBox.Location = new Point(7, 147);
         _syncProfileOnSceneCheckBox.Name = "_syncProfileOnSceneCheckBox";
         _syncProfileOnSceneCheckBox.Size = new Size(586, 22);
-        _syncProfileOnSceneCheckBox.TabIndex = 4;
+        _syncProfileOnSceneCheckBox.TabIndex = 5;
         _syncProfileOnSceneCheckBox.Text = "Применять профиль при смене сцены OBS";
         _syncProfileOnSceneCheckBox.UseVisualStyleBackColor = true;
         _syncProfileOnSceneCheckBox.CheckedChanged += OnSettingChanged;
@@ -187,10 +205,12 @@ partial class ObsIntegrationSettingsControl
         _formLayout.Controls.Add(_sizeFlowPanel, 1, 7);
         _formLayout.Controls.Add(_overlayUrlLabel, 0, 8);
         _formLayout.Controls.Add(_overlayUrlTextBox, 1, 8);
+        _formLayout.Controls.Add(_chatRefreshSourcesLabel, 0, 9);
+        _formLayout.Controls.Add(_chatRefreshSourcesCheckedListBox, 1, 9);
         _formLayout.Dock = DockStyle.Fill;
-        _formLayout.Location = new Point(7, 91);
+        _formLayout.Location = new Point(7, 175);
         _formLayout.Name = "_formLayout";
-        _formLayout.RowCount = 10;
+        _formLayout.RowCount = 11;
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
@@ -200,9 +220,10 @@ partial class ObsIntegrationSettingsControl
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 90F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _formLayout.Size = new Size(586, 392);
-        _formLayout.TabIndex = 5;
+        _formLayout.Size = new Size(586, 482);
+        _formLayout.TabIndex = 6;
         //
         // _hostLabel
         //
@@ -458,15 +479,42 @@ partial class ObsIntegrationSettingsControl
         _overlayUrlTextBox.Size = new Size(436, 23);
         _overlayUrlTextBox.TabIndex = 17;
         //
+        // _chatRefreshSourcesLabel
+        //
+        _chatRefreshSourcesLabel.AutoSize = true;
+        _chatRefreshSourcesLabel.Dock = DockStyle.Fill;
+        _chatRefreshSourcesLabel.Location = new Point(0, 288);
+        _chatRefreshSourcesLabel.Margin = new Padding(0, 0, 6, 4);
+        _chatRefreshSourcesLabel.Name = "_chatRefreshSourcesLabel";
+        _chatRefreshSourcesLabel.Size = new Size(144, 86);
+        _chatRefreshSourcesLabel.TabIndex = 18;
+        _chatRefreshSourcesLabel.Text = "Чат-источники для refresh:";
+        _chatRefreshSourcesLabel.TextAlign = ContentAlignment.TopLeft;
+        //
+        // _chatRefreshSourcesCheckedListBox
+        //
+        _chatRefreshSourcesCheckedListBox.CheckOnClick = true;
+        _chatRefreshSourcesCheckedListBox.Dock = DockStyle.Fill;
+        _chatRefreshSourcesCheckedListBox.FormattingEnabled = true;
+        _chatRefreshSourcesCheckedListBox.IntegralHeight = false;
+        _chatRefreshSourcesCheckedListBox.Location = new Point(150, 291);
+        _chatRefreshSourcesCheckedListBox.Margin = new Padding(0, 3, 0, 4);
+        _chatRefreshSourcesCheckedListBox.Name = "_chatRefreshSourcesCheckedListBox";
+        _chatRefreshSourcesCheckedListBox.Size = new Size(436, 79);
+        _chatRefreshSourcesCheckedListBox.TabIndex = 19;
+        _chatRefreshSourcesCheckedListBox.ItemCheck += OnSettingChanged;
+        _hintToolTip.SetToolTip(_chatRefreshSourcesCheckedListBox,
+            "Выберите Browser Source-источники чата для жёсткого refresh. Пусто = использовать поле \"Источник\".");
+        //
         // _statusLabel
         //
         _statusLabel.AutoEllipsis = true;
         _statusLabel.Dock = DockStyle.Fill;
         _statusLabel.ForeColor = Color.Gray;
-        _statusLabel.Location = new Point(7, 486);
+        _statusLabel.Location = new Point(7, 660);
         _statusLabel.Name = "_statusLabel";
         _statusLabel.Size = new Size(586, 30);
-        _statusLabel.TabIndex = 6;
+        _statusLabel.TabIndex = 7;
         _statusLabel.Text = "● Не проверено";
         _statusLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
@@ -476,12 +524,13 @@ partial class ObsIntegrationSettingsControl
         _buttonPanel.Controls.Add(_reconnectButton);
         _buttonPanel.Controls.Add(_loadScenesButton);
         _buttonPanel.Controls.Add(_provisionButton);
+        _buttonPanel.Controls.Add(_refreshChatNowButton);
         _buttonPanel.Controls.Add(_copyUrlButton);
         _buttonPanel.Dock = DockStyle.Fill;
-        _buttonPanel.Location = new Point(7, 519);
+        _buttonPanel.Location = new Point(7, 693);
         _buttonPanel.Name = "_buttonPanel";
         _buttonPanel.Size = new Size(586, 28);
-        _buttonPanel.TabIndex = 7;
+        _buttonPanel.TabIndex = 8;
         //
         // _testConnectionButton
         //
@@ -527,13 +576,24 @@ partial class ObsIntegrationSettingsControl
         _provisionButton.UseVisualStyleBackColor = true;
         _provisionButton.Click += OnProvisionButtonClicked;
         //
+        // _refreshChatNowButton
+        //
+        _refreshChatNowButton.Location = new Point(474, 0);
+        _refreshChatNowButton.Margin = new Padding(0, 0, 3, 0);
+        _refreshChatNowButton.Name = "_refreshChatNowButton";
+        _refreshChatNowButton.Size = new Size(140, 27);
+        _refreshChatNowButton.TabIndex = 4;
+        _refreshChatNowButton.Text = "Обновить чат сейчас";
+        _refreshChatNowButton.UseVisualStyleBackColor = true;
+        _refreshChatNowButton.Click += OnRefreshChatNowButtonClicked;
+        //
         // _copyUrlButton
         //
-        _copyUrlButton.Location = new Point(474, 0);
+        _copyUrlButton.Location = new Point(617, 0);
         _copyUrlButton.Margin = new Padding(0, 0, 3, 0);
         _copyUrlButton.Name = "_copyUrlButton";
         _copyUrlButton.Size = new Size(110, 27);
-        _copyUrlButton.TabIndex = 4;
+        _copyUrlButton.TabIndex = 5;
         _copyUrlButton.Text = "Копировать URL";
         _copyUrlButton.UseVisualStyleBackColor = true;
         _copyUrlButton.Click += OnCopyUrlButtonClicked;
@@ -544,7 +604,7 @@ partial class ObsIntegrationSettingsControl
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_rootLayout);
         Name = "ObsIntegrationSettingsControl";
-        Size = new Size(600, 614);
+        Size = new Size(600, 732);
         _rootLayout.ResumeLayout(false);
         _rootLayout.PerformLayout();
         _formLayout.ResumeLayout(false);
@@ -565,6 +625,7 @@ partial class ObsIntegrationSettingsControl
     private CheckBox _enabledCheckBox;
     private CheckBox _autoConnectCheckBox;
     private CheckBox _autoProvisionCheckBox;
+    private CheckBox _refreshOnStreamStartCheckBox;
     private CheckBox _syncSceneOnProfileCheckBox;
     private CheckBox _syncProfileOnSceneCheckBox;
     private TableLayoutPanel _formLayout;
@@ -578,6 +639,8 @@ partial class ObsIntegrationSettingsControl
     private ComboBox _sceneComboBox;
     private Label _sourcesLabel;
     private CheckedListBox _sourcesCheckedListBox;
+    private Label _chatRefreshSourcesLabel;
+    private CheckedListBox _chatRefreshSourcesCheckedListBox;
     private ToolTip _hintToolTip;
     private Label _volumeMeterDelayLabel;
     private NumericUpDown _volumeMeterDelayNumeric;
@@ -596,5 +659,6 @@ partial class ObsIntegrationSettingsControl
     private Button _reconnectButton;
     private Button _loadScenesButton;
     private Button _provisionButton;
+    private Button _refreshChatNowButton;
     private Button _copyUrlButton;
 }

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
@@ -31,26 +31,25 @@ partial class ObsIntegrationSettingsControl
         components = new System.ComponentModel.Container();
         _rootLayout = new TableLayoutPanel();
         _enabledCheckBox = new CheckBox();
+        _subTabControl = new TabControl();
+        _connectionTabPage = new TabPage();
+        _connectionLayout = new TableLayoutPanel();
         _autoConnectCheckBox = new CheckBox();
-        _autoProvisionCheckBox = new CheckBox();
-        _refreshOnStreamStartCheckBox = new CheckBox();
-        _syncSceneOnProfileCheckBox = new CheckBox();
-        _syncProfileOnSceneCheckBox = new CheckBox();
-        _formLayout = new TableLayoutPanel();
         _hostLabel = new Label();
         _hostTextBox = new TextBox();
         _portLabel = new Label();
         _portNumeric = new NumericUpDown();
         _passwordLabel = new Label();
         _passwordTextBox = new TextBox();
+        _connectionButtonPanel = new FlowLayoutPanel();
+        _testConnectionButton = new Button();
+        _reconnectButton = new Button();
+        _loadScenesButton = new Button();
+        _browserSourceTabPage = new TabPage();
+        _browserSourceLayout = new TableLayoutPanel();
+        _autoProvisionCheckBox = new CheckBox();
         _sceneLabel = new Label();
         _sceneComboBox = new ComboBox();
-        _sourcesLabel = new Label();
-        _sourcesCheckedListBox = new CheckedListBox();
-        _chatRefreshSourcesLabel = new Label();
-        _chatRefreshSourcesCheckedListBox = new CheckedListBox();
-        _volumeMeterDelayLabel = new Label();
-        _volumeMeterDelayNumeric = new NumericUpDown();
         _sourceNameLabel = new Label();
         _sourceNameTextBox = new TextBox();
         _sizeLabel = new Label();
@@ -60,23 +59,48 @@ partial class ObsIntegrationSettingsControl
         _heightNumeric = new NumericUpDown();
         _overlayUrlLabel = new Label();
         _overlayUrlTextBox = new TextBox();
-        _statusLabel = new Label();
-        _buttonPanel = new FlowLayoutPanel();
-        _testConnectionButton = new Button();
-        _reconnectButton = new Button();
-        _loadScenesButton = new Button();
+        _browserSourceButtonPanel = new FlowLayoutPanel();
         _provisionButton = new Button();
-        _refreshChatNowButton = new Button();
         _copyUrlButton = new Button();
+        _chatRefreshTabPage = new TabPage();
+        _chatRefreshLayout = new TableLayoutPanel();
+        _refreshOnStreamStartCheckBox = new CheckBox();
+        _chatRefreshSourcesLabel = new Label();
+        _chatRefreshSourcesCheckedListBox = new CheckedListBox();
+        _chatRefreshButtonPanel = new FlowLayoutPanel();
+        _refreshChatNowButton = new Button();
+        _dashboardWidgetTabPage = new TabPage();
+        _dashboardWidgetLayout = new TableLayoutPanel();
+        _volumeMeterDelayLabel = new Label();
+        _volumeMeterDelayNumeric = new NumericUpDown();
+        _sourcesLabel = new Label();
+        _sourcesCheckedListBox = new CheckedListBox();
+        _syncTabPage = new TabPage();
+        _syncLayout = new TableLayoutPanel();
+        _syncSceneOnProfileCheckBox = new CheckBox();
+        _syncProfileOnSceneCheckBox = new CheckBox();
+        _statusLabel = new Label();
         _hintToolTip = new ToolTip(components);
         _rootLayout.SuspendLayout();
-        _formLayout.SuspendLayout();
+        _subTabControl.SuspendLayout();
+        _connectionTabPage.SuspendLayout();
+        _connectionLayout.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)_portNumeric).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)_volumeMeterDelayNumeric).BeginInit();
+        _connectionButtonPanel.SuspendLayout();
+        _browserSourceTabPage.SuspendLayout();
+        _browserSourceLayout.SuspendLayout();
         _sizeFlowPanel.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)_widthNumeric).BeginInit();
         ((System.ComponentModel.ISupportInitialize)_heightNumeric).BeginInit();
-        _buttonPanel.SuspendLayout();
+        _browserSourceButtonPanel.SuspendLayout();
+        _chatRefreshTabPage.SuspendLayout();
+        _chatRefreshLayout.SuspendLayout();
+        _chatRefreshButtonPanel.SuspendLayout();
+        _dashboardWidgetTabPage.SuspendLayout();
+        _dashboardWidgetLayout.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)_volumeMeterDelayNumeric).BeginInit();
+        _syncTabPage.SuspendLayout();
+        _syncLayout.SuspendLayout();
         SuspendLayout();
         //
         // _rootLayout
@@ -84,30 +108,17 @@ partial class ObsIntegrationSettingsControl
         _rootLayout.ColumnCount = 1;
         _rootLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
         _rootLayout.Controls.Add(_enabledCheckBox, 0, 0);
-        _rootLayout.Controls.Add(_autoConnectCheckBox, 0, 1);
-        _rootLayout.Controls.Add(_autoProvisionCheckBox, 0, 2);
-        _rootLayout.Controls.Add(_refreshOnStreamStartCheckBox, 0, 3);
-        _rootLayout.Controls.Add(_syncSceneOnProfileCheckBox, 0, 4);
-        _rootLayout.Controls.Add(_syncProfileOnSceneCheckBox, 0, 5);
-        _rootLayout.Controls.Add(_formLayout, 0, 6);
-        _rootLayout.Controls.Add(_statusLabel, 0, 7);
-        _rootLayout.Controls.Add(_buttonPanel, 0, 8);
+        _rootLayout.Controls.Add(_subTabControl, 0, 1);
+        _rootLayout.Controls.Add(_statusLabel, 0, 2);
         _rootLayout.Dock = DockStyle.Fill;
         _rootLayout.Location = new Point(0, 0);
         _rootLayout.Name = "_rootLayout";
         _rootLayout.Padding = new Padding(4, 4, 4, 4);
-        _rootLayout.RowCount = 10;
+        _rootLayout.RowCount = 3;
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 488F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _rootLayout.Size = new Size(600, 732);
+        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
+        _rootLayout.Size = new Size(600, 560);
         _rootLayout.TabIndex = 0;
         //
         // _enabledCheckBox
@@ -122,154 +133,116 @@ partial class ObsIntegrationSettingsControl
         _enabledCheckBox.UseVisualStyleBackColor = true;
         _enabledCheckBox.CheckedChanged += OnSettingChanged;
         //
+        // _subTabControl
+        //
+        _subTabControl.Controls.Add(_connectionTabPage);
+        _subTabControl.Controls.Add(_browserSourceTabPage);
+        _subTabControl.Controls.Add(_chatRefreshTabPage);
+        _subTabControl.Controls.Add(_dashboardWidgetTabPage);
+        _subTabControl.Controls.Add(_syncTabPage);
+        _subTabControl.Dock = DockStyle.Fill;
+        _subTabControl.Location = new Point(7, 35);
+        _subTabControl.Name = "_subTabControl";
+        _subTabControl.Padding = new Point(0, 0);
+        _subTabControl.SelectedIndex = 0;
+        _subTabControl.Size = new Size(586, 462);
+        _subTabControl.TabIndex = 1;
+        //
+        // _connectionTabPage
+        //
+        _connectionTabPage.Controls.Add(_connectionLayout);
+        _connectionTabPage.Location = new Point(4, 24);
+        _connectionTabPage.Name = "_connectionTabPage";
+        _connectionTabPage.Padding = new Padding(8, 8, 8, 8);
+        _connectionTabPage.Size = new Size(578, 434);
+        _connectionTabPage.TabIndex = 0;
+        _connectionTabPage.Text = "Подключение";
+        _connectionTabPage.UseVisualStyleBackColor = true;
+        //
+        // _connectionLayout
+        //
+        _connectionLayout.ColumnCount = 2;
+        _connectionLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150F));
+        _connectionLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _connectionLayout.Controls.Add(_autoConnectCheckBox, 0, 0);
+        _connectionLayout.Controls.Add(_hostLabel, 0, 1);
+        _connectionLayout.Controls.Add(_hostTextBox, 1, 1);
+        _connectionLayout.Controls.Add(_portLabel, 0, 2);
+        _connectionLayout.Controls.Add(_portNumeric, 1, 2);
+        _connectionLayout.Controls.Add(_passwordLabel, 0, 3);
+        _connectionLayout.Controls.Add(_passwordTextBox, 1, 3);
+        _connectionLayout.Controls.Add(_connectionButtonPanel, 0, 5);
+        _connectionLayout.Dock = DockStyle.Fill;
+        _connectionLayout.Location = new Point(8, 8);
+        _connectionLayout.Name = "_connectionLayout";
+        _connectionLayout.RowCount = 6;
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _connectionLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
+        _connectionLayout.Size = new Size(562, 418);
+        _connectionLayout.TabIndex = 0;
+        //
         // _autoConnectCheckBox
         //
         _autoConnectCheckBox.AutoSize = true;
+        _connectionLayout.SetColumnSpan(_autoConnectCheckBox, 2);
         _autoConnectCheckBox.Dock = DockStyle.Fill;
-        _autoConnectCheckBox.Location = new Point(7, 35);
+        _autoConnectCheckBox.Location = new Point(3, 3);
         _autoConnectCheckBox.Name = "_autoConnectCheckBox";
-        _autoConnectCheckBox.Size = new Size(586, 22);
-        _autoConnectCheckBox.TabIndex = 1;
+        _autoConnectCheckBox.Size = new Size(556, 22);
+        _autoConnectCheckBox.TabIndex = 0;
         _autoConnectCheckBox.Text = "Подключаться к OBS при запуске приложения";
         _autoConnectCheckBox.UseVisualStyleBackColor = true;
         _autoConnectCheckBox.CheckedChanged += OnSettingChanged;
-        //
-        // _autoProvisionCheckBox
-        //
-        _autoProvisionCheckBox.AutoSize = true;
-        _autoProvisionCheckBox.Dock = DockStyle.Fill;
-        _autoProvisionCheckBox.Location = new Point(7, 63);
-        _autoProvisionCheckBox.Name = "_autoProvisionCheckBox";
-        _autoProvisionCheckBox.Size = new Size(586, 22);
-        _autoProvisionCheckBox.TabIndex = 2;
-        _autoProvisionCheckBox.Text = "Автоматически создавать или обновлять Browser Source";
-        _autoProvisionCheckBox.UseVisualStyleBackColor = true;
-        _autoProvisionCheckBox.CheckedChanged += OnSettingChanged;
-        //
-        // _refreshOnStreamStartCheckBox
-        //
-        _refreshOnStreamStartCheckBox.AutoSize = true;
-        _refreshOnStreamStartCheckBox.Dock = DockStyle.Fill;
-        _refreshOnStreamStartCheckBox.Location = new Point(7, 91);
-        _refreshOnStreamStartCheckBox.Name = "_refreshOnStreamStartCheckBox";
-        _refreshOnStreamStartCheckBox.Size = new Size(586, 22);
-        _refreshOnStreamStartCheckBox.TabIndex = 3;
-        _refreshOnStreamStartCheckBox.Text = "Жёстко обновлять чат-источники при старте эфира в OBS";
-        _refreshOnStreamStartCheckBox.UseVisualStyleBackColor = true;
-        _refreshOnStreamStartCheckBox.CheckedChanged += OnSettingChanged;
-        //
-        // _syncSceneOnProfileCheckBox
-        //
-        _syncSceneOnProfileCheckBox.AutoSize = true;
-        _syncSceneOnProfileCheckBox.Dock = DockStyle.Fill;
-        _syncSceneOnProfileCheckBox.Location = new Point(7, 119);
-        _syncSceneOnProfileCheckBox.Name = "_syncSceneOnProfileCheckBox";
-        _syncSceneOnProfileCheckBox.Size = new Size(586, 22);
-        _syncSceneOnProfileCheckBox.TabIndex = 4;
-        _syncSceneOnProfileCheckBox.Text = "Переключать сцену OBS при смене профиля";
-        _syncSceneOnProfileCheckBox.UseVisualStyleBackColor = true;
-        _syncSceneOnProfileCheckBox.CheckedChanged += OnSettingChanged;
-        //
-        // _syncProfileOnSceneCheckBox
-        //
-        _syncProfileOnSceneCheckBox.AutoSize = true;
-        _syncProfileOnSceneCheckBox.Dock = DockStyle.Fill;
-        _syncProfileOnSceneCheckBox.Location = new Point(7, 147);
-        _syncProfileOnSceneCheckBox.Name = "_syncProfileOnSceneCheckBox";
-        _syncProfileOnSceneCheckBox.Size = new Size(586, 22);
-        _syncProfileOnSceneCheckBox.TabIndex = 5;
-        _syncProfileOnSceneCheckBox.Text = "Применять профиль при смене сцены OBS";
-        _syncProfileOnSceneCheckBox.UseVisualStyleBackColor = true;
-        _syncProfileOnSceneCheckBox.CheckedChanged += OnSettingChanged;
-        //
-        // _formLayout
-        //
-        _formLayout.ColumnCount = 2;
-        _formLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150F));
-        _formLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-        _formLayout.Controls.Add(_hostLabel, 0, 0);
-        _formLayout.Controls.Add(_hostTextBox, 1, 0);
-        _formLayout.Controls.Add(_portLabel, 0, 1);
-        _formLayout.Controls.Add(_portNumeric, 1, 1);
-        _formLayout.Controls.Add(_passwordLabel, 0, 2);
-        _formLayout.Controls.Add(_passwordTextBox, 1, 2);
-        _formLayout.Controls.Add(_sceneLabel, 0, 3);
-        _formLayout.Controls.Add(_sceneComboBox, 1, 3);
-        _formLayout.Controls.Add(_sourcesLabel, 0, 4);
-        _formLayout.Controls.Add(_sourcesCheckedListBox, 1, 4);
-        _formLayout.Controls.Add(_volumeMeterDelayLabel, 0, 5);
-        _formLayout.Controls.Add(_volumeMeterDelayNumeric, 1, 5);
-        _formLayout.Controls.Add(_sourceNameLabel, 0, 6);
-        _formLayout.Controls.Add(_sourceNameTextBox, 1, 6);
-        _formLayout.Controls.Add(_sizeLabel, 0, 7);
-        _formLayout.Controls.Add(_sizeFlowPanel, 1, 7);
-        _formLayout.Controls.Add(_overlayUrlLabel, 0, 8);
-        _formLayout.Controls.Add(_overlayUrlTextBox, 1, 8);
-        _formLayout.Controls.Add(_chatRefreshSourcesLabel, 0, 9);
-        _formLayout.Controls.Add(_chatRefreshSourcesCheckedListBox, 1, 9);
-        _formLayout.Dock = DockStyle.Fill;
-        _formLayout.Location = new Point(7, 175);
-        _formLayout.Name = "_formLayout";
-        _formLayout.RowCount = 11;
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 110F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 90F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _formLayout.Size = new Size(586, 482);
-        _formLayout.TabIndex = 6;
         //
         // _hostLabel
         //
         _hostLabel.AutoSize = true;
         _hostLabel.Dock = DockStyle.Fill;
-        _hostLabel.Location = new Point(0, 0);
+        _hostLabel.Location = new Point(0, 28);
         _hostLabel.Margin = new Padding(0, 0, 6, 4);
         _hostLabel.Name = "_hostLabel";
         _hostLabel.Size = new Size(144, 28);
-        _hostLabel.TabIndex = 0;
+        _hostLabel.TabIndex = 1;
         _hostLabel.Text = "Хост:";
         _hostLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
         // _hostTextBox
         //
         _hostTextBox.Dock = DockStyle.Fill;
-        _hostTextBox.Location = new Point(150, 3);
+        _hostTextBox.Location = new Point(150, 31);
         _hostTextBox.Margin = new Padding(0, 3, 0, 4);
         _hostTextBox.Name = "_hostTextBox";
         _hostTextBox.PlaceholderText = "127.0.0.1";
-        _hostTextBox.Size = new Size(436, 23);
-        _hostTextBox.TabIndex = 1;
+        _hostTextBox.Size = new Size(412, 23);
+        _hostTextBox.TabIndex = 2;
         _hostTextBox.TextChanged += OnConnectionFieldChanged;
         //
         // _portLabel
         //
         _portLabel.AutoSize = true;
         _portLabel.Dock = DockStyle.Fill;
-        _portLabel.Location = new Point(0, 32);
+        _portLabel.Location = new Point(0, 60);
         _portLabel.Margin = new Padding(0, 0, 6, 4);
         _portLabel.Name = "_portLabel";
         _portLabel.Size = new Size(144, 28);
-        _portLabel.TabIndex = 2;
+        _portLabel.TabIndex = 3;
         _portLabel.Text = "Порт:";
         _portLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
         // _portNumeric
         //
         _portNumeric.Dock = DockStyle.Left;
-        _portNumeric.Location = new Point(150, 35);
+        _portNumeric.Location = new Point(150, 63);
         _portNumeric.Margin = new Padding(0, 3, 0, 4);
         _portNumeric.Maximum = new decimal(new int[] { 65535, 0, 0, 0 });
         _portNumeric.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
         _portNumeric.Name = "_portNumeric";
         _portNumeric.Size = new Size(100, 23);
-        _portNumeric.TabIndex = 3;
+        _portNumeric.TabIndex = 4;
         _portNumeric.Value = new decimal(new int[] { 4455, 0, 0, 0 });
         _portNumeric.ValueChanged += OnConnectionFieldChanged;
         //
@@ -277,34 +250,133 @@ partial class ObsIntegrationSettingsControl
         //
         _passwordLabel.AutoSize = true;
         _passwordLabel.Dock = DockStyle.Fill;
-        _passwordLabel.Location = new Point(0, 64);
+        _passwordLabel.Location = new Point(0, 92);
         _passwordLabel.Margin = new Padding(0, 0, 6, 4);
         _passwordLabel.Name = "_passwordLabel";
         _passwordLabel.Size = new Size(144, 28);
-        _passwordLabel.TabIndex = 4;
+        _passwordLabel.TabIndex = 5;
         _passwordLabel.Text = "Пароль:";
         _passwordLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
         // _passwordTextBox
         //
         _passwordTextBox.Dock = DockStyle.Fill;
-        _passwordTextBox.Location = new Point(150, 67);
+        _passwordTextBox.Location = new Point(150, 95);
         _passwordTextBox.Margin = new Padding(0, 3, 0, 4);
         _passwordTextBox.Name = "_passwordTextBox";
-        _passwordTextBox.Size = new Size(436, 23);
-        _passwordTextBox.TabIndex = 5;
+        _passwordTextBox.Size = new Size(412, 23);
+        _passwordTextBox.TabIndex = 6;
         _passwordTextBox.UseSystemPasswordChar = true;
         _passwordTextBox.TextChanged += OnConnectionFieldChanged;
+        //
+        // _connectionButtonPanel
+        //
+        _connectionLayout.SetColumnSpan(_connectionButtonPanel, 2);
+        _connectionButtonPanel.Controls.Add(_testConnectionButton);
+        _connectionButtonPanel.Controls.Add(_reconnectButton);
+        _connectionButtonPanel.Controls.Add(_loadScenesButton);
+        _connectionButtonPanel.Dock = DockStyle.Fill;
+        _connectionButtonPanel.Location = new Point(0, 384);
+        _connectionButtonPanel.Margin = new Padding(0, 0, 0, 0);
+        _connectionButtonPanel.Name = "_connectionButtonPanel";
+        _connectionButtonPanel.Size = new Size(562, 34);
+        _connectionButtonPanel.TabIndex = 7;
+        //
+        // _testConnectionButton
+        //
+        _testConnectionButton.Location = new Point(0, 0);
+        _testConnectionButton.Margin = new Padding(0, 0, 3, 0);
+        _testConnectionButton.Name = "_testConnectionButton";
+        _testConnectionButton.Size = new Size(102, 27);
+        _testConnectionButton.TabIndex = 0;
+        _testConnectionButton.Text = "Проверить";
+        _testConnectionButton.UseVisualStyleBackColor = true;
+        _testConnectionButton.Click += OnTestConnectionButtonClicked;
+        //
+        // _reconnectButton
+        //
+        _reconnectButton.Location = new Point(105, 0);
+        _reconnectButton.Margin = new Padding(0, 0, 3, 0);
+        _reconnectButton.Name = "_reconnectButton";
+        _reconnectButton.Size = new Size(125, 27);
+        _reconnectButton.TabIndex = 1;
+        _reconnectButton.Text = "Переподключить";
+        _reconnectButton.UseVisualStyleBackColor = true;
+        _reconnectButton.Click += OnReconnectButtonClicked;
+        //
+        // _loadScenesButton
+        //
+        _loadScenesButton.Location = new Point(233, 0);
+        _loadScenesButton.Margin = new Padding(0, 0, 3, 0);
+        _loadScenesButton.Name = "_loadScenesButton";
+        _loadScenesButton.Size = new Size(105, 27);
+        _loadScenesButton.TabIndex = 2;
+        _loadScenesButton.Text = "Списки";
+        _loadScenesButton.UseVisualStyleBackColor = true;
+        _loadScenesButton.Click += OnLoadScenesButtonClicked;
+        //
+        // _browserSourceTabPage
+        //
+        _browserSourceTabPage.Controls.Add(_browserSourceLayout);
+        _browserSourceTabPage.Location = new Point(4, 24);
+        _browserSourceTabPage.Name = "_browserSourceTabPage";
+        _browserSourceTabPage.Padding = new Padding(8, 8, 8, 8);
+        _browserSourceTabPage.Size = new Size(578, 434);
+        _browserSourceTabPage.TabIndex = 1;
+        _browserSourceTabPage.Text = "Browser Source";
+        _browserSourceTabPage.UseVisualStyleBackColor = true;
+        //
+        // _browserSourceLayout
+        //
+        _browserSourceLayout.ColumnCount = 2;
+        _browserSourceLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150F));
+        _browserSourceLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _browserSourceLayout.Controls.Add(_autoProvisionCheckBox, 0, 0);
+        _browserSourceLayout.Controls.Add(_sceneLabel, 0, 1);
+        _browserSourceLayout.Controls.Add(_sceneComboBox, 1, 1);
+        _browserSourceLayout.Controls.Add(_sourceNameLabel, 0, 2);
+        _browserSourceLayout.Controls.Add(_sourceNameTextBox, 1, 2);
+        _browserSourceLayout.Controls.Add(_sizeLabel, 0, 3);
+        _browserSourceLayout.Controls.Add(_sizeFlowPanel, 1, 3);
+        _browserSourceLayout.Controls.Add(_overlayUrlLabel, 0, 4);
+        _browserSourceLayout.Controls.Add(_overlayUrlTextBox, 1, 4);
+        _browserSourceLayout.Controls.Add(_browserSourceButtonPanel, 0, 6);
+        _browserSourceLayout.Dock = DockStyle.Fill;
+        _browserSourceLayout.Location = new Point(8, 8);
+        _browserSourceLayout.Name = "_browserSourceLayout";
+        _browserSourceLayout.RowCount = 7;
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _browserSourceLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
+        _browserSourceLayout.Size = new Size(562, 418);
+        _browserSourceLayout.TabIndex = 0;
+        //
+        // _autoProvisionCheckBox
+        //
+        _autoProvisionCheckBox.AutoSize = true;
+        _browserSourceLayout.SetColumnSpan(_autoProvisionCheckBox, 2);
+        _autoProvisionCheckBox.Dock = DockStyle.Fill;
+        _autoProvisionCheckBox.Location = new Point(3, 3);
+        _autoProvisionCheckBox.Name = "_autoProvisionCheckBox";
+        _autoProvisionCheckBox.Size = new Size(556, 22);
+        _autoProvisionCheckBox.TabIndex = 0;
+        _autoProvisionCheckBox.Text = "Автоматически создавать или обновлять Browser Source";
+        _autoProvisionCheckBox.UseVisualStyleBackColor = true;
+        _autoProvisionCheckBox.CheckedChanged += OnSettingChanged;
         //
         // _sceneLabel
         //
         _sceneLabel.AutoSize = true;
         _sceneLabel.Dock = DockStyle.Fill;
-        _sceneLabel.Location = new Point(0, 96);
+        _sceneLabel.Location = new Point(0, 28);
         _sceneLabel.Margin = new Padding(0, 0, 6, 4);
         _sceneLabel.Name = "_sceneLabel";
         _sceneLabel.Size = new Size(144, 28);
-        _sceneLabel.TabIndex = 6;
+        _sceneLabel.TabIndex = 1;
         _sceneLabel.Text = "Сцена:";
         _sceneLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
@@ -312,102 +384,46 @@ partial class ObsIntegrationSettingsControl
         //
         _sceneComboBox.Dock = DockStyle.Fill;
         _sceneComboBox.FormattingEnabled = true;
-        _sceneComboBox.Location = new Point(150, 99);
+        _sceneComboBox.Location = new Point(150, 31);
         _sceneComboBox.Margin = new Padding(0, 3, 0, 4);
         _sceneComboBox.Name = "_sceneComboBox";
-        _sceneComboBox.Size = new Size(436, 23);
-        _sceneComboBox.TabIndex = 7;
+        _sceneComboBox.Size = new Size(412, 23);
+        _sceneComboBox.TabIndex = 2;
         _sceneComboBox.SelectedIndexChanged += OnSettingChanged;
         _sceneComboBox.TextChanged += OnSettingChanged;
-        //
-        // _sourcesLabel
-        //
-        _sourcesLabel.AutoSize = true;
-        _sourcesLabel.Dock = DockStyle.Fill;
-        _sourcesLabel.Location = new Point(0, 128);
-        _sourcesLabel.Margin = new Padding(0, 0, 6, 4);
-        _sourcesLabel.Name = "_sourcesLabel";
-        _sourcesLabel.Size = new Size(144, 106);
-        _sourcesLabel.TabIndex = 8;
-        _sourcesLabel.Text = "Источники виджета:";
-        _sourcesLabel.TextAlign = ContentAlignment.TopLeft;
-        //
-        // _sourcesCheckedListBox
-        //
-        _sourcesCheckedListBox.CheckOnClick = true;
-        _sourcesCheckedListBox.Dock = DockStyle.Fill;
-        _sourcesCheckedListBox.FormattingEnabled = true;
-        _sourcesCheckedListBox.IntegralHeight = false;
-        _sourcesCheckedListBox.Location = new Point(150, 131);
-        _sourcesCheckedListBox.Margin = new Padding(0, 3, 0, 4);
-        _sourcesCheckedListBox.Name = "_sourcesCheckedListBox";
-        _sourcesCheckedListBox.Size = new Size(436, 99);
-        _sourcesCheckedListBox.TabIndex = 9;
-        _sourcesCheckedListBox.ItemCheck += OnSettingChanged;
-        //
-        // _hintToolTip
-        //
-        _hintToolTip.SetToolTip(_sourcesCheckedListBox,
-            "Отметьте аудио-источники OBS для виджета. Пусто = авто-определение микрофона.");
-        //
-        // _volumeMeterDelayLabel
-        //
-        _volumeMeterDelayLabel.AutoSize = true;
-        _volumeMeterDelayLabel.Dock = DockStyle.Fill;
-        _volumeMeterDelayLabel.Location = new Point(0, 160);
-        _volumeMeterDelayLabel.Margin = new Padding(0, 0, 6, 4);
-        _volumeMeterDelayLabel.Name = "_volumeMeterDelayLabel";
-        _volumeMeterDelayLabel.Size = new Size(144, 28);
-        _volumeMeterDelayLabel.TabIndex = 10;
-        _volumeMeterDelayLabel.Text = "Задержка шкалы, мс:";
-        _volumeMeterDelayLabel.TextAlign = ContentAlignment.MiddleLeft;
-        //
-        // _volumeMeterDelayNumeric
-        //
-        _volumeMeterDelayNumeric.Dock = DockStyle.Left;
-        _volumeMeterDelayNumeric.Increment = new decimal(new int[] { 10, 0, 0, 0 });
-        _volumeMeterDelayNumeric.Location = new Point(150, 163);
-        _volumeMeterDelayNumeric.Margin = new Padding(0, 3, 0, 4);
-        _volumeMeterDelayNumeric.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
-        _volumeMeterDelayNumeric.Minimum = new decimal(new int[] { 30, 0, 0, 0 });
-        _volumeMeterDelayNumeric.Name = "_volumeMeterDelayNumeric";
-        _volumeMeterDelayNumeric.Size = new Size(100, 23);
-        _volumeMeterDelayNumeric.TabIndex = 11;
-        _volumeMeterDelayNumeric.Value = new decimal(new int[] { 120, 0, 0, 0 });
-        _volumeMeterDelayNumeric.ValueChanged += OnSettingChanged;
         //
         // _sourceNameLabel
         //
         _sourceNameLabel.AutoSize = true;
         _sourceNameLabel.Dock = DockStyle.Fill;
-        _sourceNameLabel.Location = new Point(0, 192);
+        _sourceNameLabel.Location = new Point(0, 60);
         _sourceNameLabel.Margin = new Padding(0, 0, 6, 4);
         _sourceNameLabel.Name = "_sourceNameLabel";
         _sourceNameLabel.Size = new Size(144, 28);
-        _sourceNameLabel.TabIndex = 12;
+        _sourceNameLabel.TabIndex = 3;
         _sourceNameLabel.Text = "Источник:";
         _sourceNameLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
         // _sourceNameTextBox
         //
         _sourceNameTextBox.Dock = DockStyle.Fill;
-        _sourceNameTextBox.Location = new Point(150, 195);
+        _sourceNameTextBox.Location = new Point(150, 63);
         _sourceNameTextBox.Margin = new Padding(0, 3, 0, 4);
         _sourceNameTextBox.Name = "_sourceNameTextBox";
         _sourceNameTextBox.PlaceholderText = "PoproshaykaBot Chat";
-        _sourceNameTextBox.Size = new Size(436, 23);
-        _sourceNameTextBox.TabIndex = 13;
+        _sourceNameTextBox.Size = new Size(412, 23);
+        _sourceNameTextBox.TabIndex = 4;
         _sourceNameTextBox.TextChanged += OnSettingChanged;
         //
         // _sizeLabel
         //
         _sizeLabel.AutoSize = true;
         _sizeLabel.Dock = DockStyle.Fill;
-        _sizeLabel.Location = new Point(0, 224);
+        _sizeLabel.Location = new Point(0, 92);
         _sizeLabel.Margin = new Padding(0, 0, 6, 4);
         _sizeLabel.Name = "_sizeLabel";
         _sizeLabel.Size = new Size(144, 28);
-        _sizeLabel.TabIndex = 14;
+        _sizeLabel.TabIndex = 5;
         _sizeLabel.Text = "Размер:";
         _sizeLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
@@ -417,11 +433,11 @@ partial class ObsIntegrationSettingsControl
         _sizeFlowPanel.Controls.Add(_sizeSeparatorLabel);
         _sizeFlowPanel.Controls.Add(_heightNumeric);
         _sizeFlowPanel.Dock = DockStyle.Fill;
-        _sizeFlowPanel.Location = new Point(150, 224);
+        _sizeFlowPanel.Location = new Point(150, 92);
         _sizeFlowPanel.Margin = new Padding(0, 0, 0, 4);
         _sizeFlowPanel.Name = "_sizeFlowPanel";
-        _sizeFlowPanel.Size = new Size(436, 28);
-        _sizeFlowPanel.TabIndex = 15;
+        _sizeFlowPanel.Size = new Size(412, 28);
+        _sizeFlowPanel.TabIndex = 6;
         //
         // _widthNumeric
         //
@@ -461,33 +477,110 @@ partial class ObsIntegrationSettingsControl
         //
         _overlayUrlLabel.AutoSize = true;
         _overlayUrlLabel.Dock = DockStyle.Fill;
-        _overlayUrlLabel.Location = new Point(0, 256);
+        _overlayUrlLabel.Location = new Point(0, 124);
         _overlayUrlLabel.Margin = new Padding(0, 0, 6, 4);
         _overlayUrlLabel.Name = "_overlayUrlLabel";
         _overlayUrlLabel.Size = new Size(144, 28);
-        _overlayUrlLabel.TabIndex = 16;
+        _overlayUrlLabel.TabIndex = 7;
         _overlayUrlLabel.Text = "URL оверлея:";
         _overlayUrlLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
         // _overlayUrlTextBox
         //
         _overlayUrlTextBox.Dock = DockStyle.Fill;
-        _overlayUrlTextBox.Location = new Point(150, 259);
+        _overlayUrlTextBox.Location = new Point(150, 127);
         _overlayUrlTextBox.Margin = new Padding(0, 3, 0, 4);
         _overlayUrlTextBox.Name = "_overlayUrlTextBox";
         _overlayUrlTextBox.ReadOnly = true;
-        _overlayUrlTextBox.Size = new Size(436, 23);
-        _overlayUrlTextBox.TabIndex = 17;
+        _overlayUrlTextBox.Size = new Size(412, 23);
+        _overlayUrlTextBox.TabIndex = 8;
+        //
+        // _browserSourceButtonPanel
+        //
+        _browserSourceLayout.SetColumnSpan(_browserSourceButtonPanel, 2);
+        _browserSourceButtonPanel.Controls.Add(_provisionButton);
+        _browserSourceButtonPanel.Controls.Add(_copyUrlButton);
+        _browserSourceButtonPanel.Dock = DockStyle.Fill;
+        _browserSourceButtonPanel.Location = new Point(0, 384);
+        _browserSourceButtonPanel.Margin = new Padding(0, 0, 0, 0);
+        _browserSourceButtonPanel.Name = "_browserSourceButtonPanel";
+        _browserSourceButtonPanel.Size = new Size(562, 34);
+        _browserSourceButtonPanel.TabIndex = 9;
+        //
+        // _provisionButton
+        //
+        _provisionButton.Location = new Point(0, 0);
+        _provisionButton.Margin = new Padding(0, 0, 3, 0);
+        _provisionButton.Name = "_provisionButton";
+        _provisionButton.Size = new Size(130, 27);
+        _provisionButton.TabIndex = 0;
+        _provisionButton.Text = "Создать источник";
+        _provisionButton.UseVisualStyleBackColor = true;
+        _provisionButton.Click += OnProvisionButtonClicked;
+        //
+        // _copyUrlButton
+        //
+        _copyUrlButton.Location = new Point(133, 0);
+        _copyUrlButton.Margin = new Padding(0, 0, 3, 0);
+        _copyUrlButton.Name = "_copyUrlButton";
+        _copyUrlButton.Size = new Size(110, 27);
+        _copyUrlButton.TabIndex = 1;
+        _copyUrlButton.Text = "Копировать URL";
+        _copyUrlButton.UseVisualStyleBackColor = true;
+        _copyUrlButton.Click += OnCopyUrlButtonClicked;
+        //
+        // _chatRefreshTabPage
+        //
+        _chatRefreshTabPage.Controls.Add(_chatRefreshLayout);
+        _chatRefreshTabPage.Location = new Point(4, 24);
+        _chatRefreshTabPage.Name = "_chatRefreshTabPage";
+        _chatRefreshTabPage.Padding = new Padding(8, 8, 8, 8);
+        _chatRefreshTabPage.Size = new Size(578, 434);
+        _chatRefreshTabPage.TabIndex = 2;
+        _chatRefreshTabPage.Text = "Чат-источники";
+        _chatRefreshTabPage.UseVisualStyleBackColor = true;
+        //
+        // _chatRefreshLayout
+        //
+        _chatRefreshLayout.ColumnCount = 2;
+        _chatRefreshLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150F));
+        _chatRefreshLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _chatRefreshLayout.Controls.Add(_refreshOnStreamStartCheckBox, 0, 0);
+        _chatRefreshLayout.Controls.Add(_chatRefreshSourcesLabel, 0, 1);
+        _chatRefreshLayout.Controls.Add(_chatRefreshSourcesCheckedListBox, 1, 1);
+        _chatRefreshLayout.Controls.Add(_chatRefreshButtonPanel, 0, 2);
+        _chatRefreshLayout.Dock = DockStyle.Fill;
+        _chatRefreshLayout.Location = new Point(8, 8);
+        _chatRefreshLayout.Name = "_chatRefreshLayout";
+        _chatRefreshLayout.RowCount = 3;
+        _chatRefreshLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _chatRefreshLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _chatRefreshLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
+        _chatRefreshLayout.Size = new Size(562, 418);
+        _chatRefreshLayout.TabIndex = 0;
+        //
+        // _refreshOnStreamStartCheckBox
+        //
+        _refreshOnStreamStartCheckBox.AutoSize = true;
+        _chatRefreshLayout.SetColumnSpan(_refreshOnStreamStartCheckBox, 2);
+        _refreshOnStreamStartCheckBox.Dock = DockStyle.Fill;
+        _refreshOnStreamStartCheckBox.Location = new Point(3, 3);
+        _refreshOnStreamStartCheckBox.Name = "_refreshOnStreamStartCheckBox";
+        _refreshOnStreamStartCheckBox.Size = new Size(556, 22);
+        _refreshOnStreamStartCheckBox.TabIndex = 0;
+        _refreshOnStreamStartCheckBox.Text = "Жёстко обновлять чат-источники при старте эфира в OBS";
+        _refreshOnStreamStartCheckBox.UseVisualStyleBackColor = true;
+        _refreshOnStreamStartCheckBox.CheckedChanged += OnSettingChanged;
         //
         // _chatRefreshSourcesLabel
         //
         _chatRefreshSourcesLabel.AutoSize = true;
         _chatRefreshSourcesLabel.Dock = DockStyle.Fill;
-        _chatRefreshSourcesLabel.Location = new Point(0, 288);
+        _chatRefreshSourcesLabel.Location = new Point(0, 28);
         _chatRefreshSourcesLabel.Margin = new Padding(0, 0, 6, 4);
         _chatRefreshSourcesLabel.Name = "_chatRefreshSourcesLabel";
-        _chatRefreshSourcesLabel.Size = new Size(144, 86);
-        _chatRefreshSourcesLabel.TabIndex = 18;
+        _chatRefreshSourcesLabel.Size = new Size(144, 318);
+        _chatRefreshSourcesLabel.TabIndex = 1;
         _chatRefreshSourcesLabel.Text = "Чат-источники для refresh:";
         _chatRefreshSourcesLabel.TextAlign = ContentAlignment.TopLeft;
         //
@@ -497,106 +590,184 @@ partial class ObsIntegrationSettingsControl
         _chatRefreshSourcesCheckedListBox.Dock = DockStyle.Fill;
         _chatRefreshSourcesCheckedListBox.FormattingEnabled = true;
         _chatRefreshSourcesCheckedListBox.IntegralHeight = false;
-        _chatRefreshSourcesCheckedListBox.Location = new Point(150, 291);
+        _chatRefreshSourcesCheckedListBox.Location = new Point(150, 31);
         _chatRefreshSourcesCheckedListBox.Margin = new Padding(0, 3, 0, 4);
         _chatRefreshSourcesCheckedListBox.Name = "_chatRefreshSourcesCheckedListBox";
-        _chatRefreshSourcesCheckedListBox.Size = new Size(436, 79);
-        _chatRefreshSourcesCheckedListBox.TabIndex = 19;
+        _chatRefreshSourcesCheckedListBox.Size = new Size(412, 312);
+        _chatRefreshSourcesCheckedListBox.TabIndex = 2;
         _chatRefreshSourcesCheckedListBox.ItemCheck += OnSettingChanged;
-        _hintToolTip.SetToolTip(_chatRefreshSourcesCheckedListBox,
-            "Выберите Browser Source-источники чата для жёсткого refresh. Пусто = использовать поле \"Источник\".");
+        //
+        // _chatRefreshButtonPanel
+        //
+        _chatRefreshLayout.SetColumnSpan(_chatRefreshButtonPanel, 2);
+        _chatRefreshButtonPanel.Controls.Add(_refreshChatNowButton);
+        _chatRefreshButtonPanel.Dock = DockStyle.Fill;
+        _chatRefreshButtonPanel.Location = new Point(0, 384);
+        _chatRefreshButtonPanel.Margin = new Padding(0, 0, 0, 0);
+        _chatRefreshButtonPanel.Name = "_chatRefreshButtonPanel";
+        _chatRefreshButtonPanel.Size = new Size(562, 34);
+        _chatRefreshButtonPanel.TabIndex = 3;
+        //
+        // _refreshChatNowButton
+        //
+        _refreshChatNowButton.Location = new Point(0, 0);
+        _refreshChatNowButton.Margin = new Padding(0, 0, 3, 0);
+        _refreshChatNowButton.Name = "_refreshChatNowButton";
+        _refreshChatNowButton.Size = new Size(140, 27);
+        _refreshChatNowButton.TabIndex = 0;
+        _refreshChatNowButton.Text = "Обновить чат сейчас";
+        _refreshChatNowButton.UseVisualStyleBackColor = true;
+        _refreshChatNowButton.Click += OnRefreshChatNowButtonClicked;
+        //
+        // _dashboardWidgetTabPage
+        //
+        _dashboardWidgetTabPage.Controls.Add(_dashboardWidgetLayout);
+        _dashboardWidgetTabPage.Location = new Point(4, 24);
+        _dashboardWidgetTabPage.Name = "_dashboardWidgetTabPage";
+        _dashboardWidgetTabPage.Padding = new Padding(8, 8, 8, 8);
+        _dashboardWidgetTabPage.Size = new Size(578, 434);
+        _dashboardWidgetTabPage.TabIndex = 3;
+        _dashboardWidgetTabPage.Text = "Дашборд";
+        _dashboardWidgetTabPage.UseVisualStyleBackColor = true;
+        //
+        // _dashboardWidgetLayout
+        //
+        _dashboardWidgetLayout.ColumnCount = 2;
+        _dashboardWidgetLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150F));
+        _dashboardWidgetLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _dashboardWidgetLayout.Controls.Add(_volumeMeterDelayLabel, 0, 0);
+        _dashboardWidgetLayout.Controls.Add(_volumeMeterDelayNumeric, 1, 0);
+        _dashboardWidgetLayout.Controls.Add(_sourcesLabel, 0, 1);
+        _dashboardWidgetLayout.Controls.Add(_sourcesCheckedListBox, 1, 1);
+        _dashboardWidgetLayout.Dock = DockStyle.Fill;
+        _dashboardWidgetLayout.Location = new Point(8, 8);
+        _dashboardWidgetLayout.Name = "_dashboardWidgetLayout";
+        _dashboardWidgetLayout.RowCount = 2;
+        _dashboardWidgetLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _dashboardWidgetLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _dashboardWidgetLayout.Size = new Size(562, 418);
+        _dashboardWidgetLayout.TabIndex = 0;
+        //
+        // _volumeMeterDelayLabel
+        //
+        _volumeMeterDelayLabel.AutoSize = true;
+        _volumeMeterDelayLabel.Dock = DockStyle.Fill;
+        _volumeMeterDelayLabel.Location = new Point(0, 0);
+        _volumeMeterDelayLabel.Margin = new Padding(0, 0, 6, 4);
+        _volumeMeterDelayLabel.Name = "_volumeMeterDelayLabel";
+        _volumeMeterDelayLabel.Size = new Size(144, 28);
+        _volumeMeterDelayLabel.TabIndex = 0;
+        _volumeMeterDelayLabel.Text = "Задержка шкалы, мс:";
+        _volumeMeterDelayLabel.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // _volumeMeterDelayNumeric
+        //
+        _volumeMeterDelayNumeric.Dock = DockStyle.Left;
+        _volumeMeterDelayNumeric.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+        _volumeMeterDelayNumeric.Location = new Point(150, 3);
+        _volumeMeterDelayNumeric.Margin = new Padding(0, 3, 0, 4);
+        _volumeMeterDelayNumeric.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+        _volumeMeterDelayNumeric.Minimum = new decimal(new int[] { 30, 0, 0, 0 });
+        _volumeMeterDelayNumeric.Name = "_volumeMeterDelayNumeric";
+        _volumeMeterDelayNumeric.Size = new Size(100, 23);
+        _volumeMeterDelayNumeric.TabIndex = 1;
+        _volumeMeterDelayNumeric.Value = new decimal(new int[] { 120, 0, 0, 0 });
+        _volumeMeterDelayNumeric.ValueChanged += OnSettingChanged;
+        //
+        // _sourcesLabel
+        //
+        _sourcesLabel.AutoSize = true;
+        _sourcesLabel.Dock = DockStyle.Fill;
+        _sourcesLabel.Location = new Point(0, 32);
+        _sourcesLabel.Margin = new Padding(0, 0, 6, 4);
+        _sourcesLabel.Name = "_sourcesLabel";
+        _sourcesLabel.Size = new Size(144, 382);
+        _sourcesLabel.TabIndex = 2;
+        _sourcesLabel.Text = "Источники виджета:";
+        _sourcesLabel.TextAlign = ContentAlignment.TopLeft;
+        //
+        // _sourcesCheckedListBox
+        //
+        _sourcesCheckedListBox.CheckOnClick = true;
+        _sourcesCheckedListBox.Dock = DockStyle.Fill;
+        _sourcesCheckedListBox.FormattingEnabled = true;
+        _sourcesCheckedListBox.IntegralHeight = false;
+        _sourcesCheckedListBox.Location = new Point(150, 35);
+        _sourcesCheckedListBox.Margin = new Padding(0, 3, 0, 4);
+        _sourcesCheckedListBox.Name = "_sourcesCheckedListBox";
+        _sourcesCheckedListBox.Size = new Size(412, 379);
+        _sourcesCheckedListBox.TabIndex = 3;
+        _sourcesCheckedListBox.ItemCheck += OnSettingChanged;
+        //
+        // _syncTabPage
+        //
+        _syncTabPage.Controls.Add(_syncLayout);
+        _syncTabPage.Location = new Point(4, 24);
+        _syncTabPage.Name = "_syncTabPage";
+        _syncTabPage.Padding = new Padding(8, 8, 8, 8);
+        _syncTabPage.Size = new Size(578, 434);
+        _syncTabPage.TabIndex = 4;
+        _syncTabPage.Text = "Синхронизация";
+        _syncTabPage.UseVisualStyleBackColor = true;
+        //
+        // _syncLayout
+        //
+        _syncLayout.ColumnCount = 1;
+        _syncLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _syncLayout.Controls.Add(_syncSceneOnProfileCheckBox, 0, 0);
+        _syncLayout.Controls.Add(_syncProfileOnSceneCheckBox, 0, 1);
+        _syncLayout.Dock = DockStyle.Fill;
+        _syncLayout.Location = new Point(8, 8);
+        _syncLayout.Name = "_syncLayout";
+        _syncLayout.RowCount = 3;
+        _syncLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _syncLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+        _syncLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _syncLayout.Size = new Size(562, 418);
+        _syncLayout.TabIndex = 0;
+        //
+        // _syncSceneOnProfileCheckBox
+        //
+        _syncSceneOnProfileCheckBox.AutoSize = true;
+        _syncSceneOnProfileCheckBox.Dock = DockStyle.Fill;
+        _syncSceneOnProfileCheckBox.Location = new Point(3, 3);
+        _syncSceneOnProfileCheckBox.Name = "_syncSceneOnProfileCheckBox";
+        _syncSceneOnProfileCheckBox.Size = new Size(556, 22);
+        _syncSceneOnProfileCheckBox.TabIndex = 0;
+        _syncSceneOnProfileCheckBox.Text = "Переключать сцену OBS при смене профиля";
+        _syncSceneOnProfileCheckBox.UseVisualStyleBackColor = true;
+        _syncSceneOnProfileCheckBox.CheckedChanged += OnSettingChanged;
+        //
+        // _syncProfileOnSceneCheckBox
+        //
+        _syncProfileOnSceneCheckBox.AutoSize = true;
+        _syncProfileOnSceneCheckBox.Dock = DockStyle.Fill;
+        _syncProfileOnSceneCheckBox.Location = new Point(3, 31);
+        _syncProfileOnSceneCheckBox.Name = "_syncProfileOnSceneCheckBox";
+        _syncProfileOnSceneCheckBox.Size = new Size(556, 22);
+        _syncProfileOnSceneCheckBox.TabIndex = 1;
+        _syncProfileOnSceneCheckBox.Text = "Применять профиль при смене сцены OBS";
+        _syncProfileOnSceneCheckBox.UseVisualStyleBackColor = true;
+        _syncProfileOnSceneCheckBox.CheckedChanged += OnSettingChanged;
         //
         // _statusLabel
         //
         _statusLabel.AutoEllipsis = true;
         _statusLabel.Dock = DockStyle.Fill;
         _statusLabel.ForeColor = Color.Gray;
-        _statusLabel.Location = new Point(7, 660);
+        _statusLabel.Location = new Point(7, 527);
         _statusLabel.Name = "_statusLabel";
         _statusLabel.Size = new Size(586, 30);
-        _statusLabel.TabIndex = 7;
+        _statusLabel.TabIndex = 2;
         _statusLabel.Text = "● Не проверено";
         _statusLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
-        // _buttonPanel
+        // _hintToolTip
         //
-        _buttonPanel.Controls.Add(_testConnectionButton);
-        _buttonPanel.Controls.Add(_reconnectButton);
-        _buttonPanel.Controls.Add(_loadScenesButton);
-        _buttonPanel.Controls.Add(_provisionButton);
-        _buttonPanel.Controls.Add(_refreshChatNowButton);
-        _buttonPanel.Controls.Add(_copyUrlButton);
-        _buttonPanel.Dock = DockStyle.Fill;
-        _buttonPanel.Location = new Point(7, 693);
-        _buttonPanel.Name = "_buttonPanel";
-        _buttonPanel.Size = new Size(586, 28);
-        _buttonPanel.TabIndex = 8;
-        //
-        // _testConnectionButton
-        //
-        _testConnectionButton.Location = new Point(0, 0);
-        _testConnectionButton.Margin = new Padding(0, 0, 3, 0);
-        _testConnectionButton.Name = "_testConnectionButton";
-        _testConnectionButton.Size = new Size(102, 27);
-        _testConnectionButton.TabIndex = 0;
-        _testConnectionButton.Text = "Проверить";
-        _testConnectionButton.UseVisualStyleBackColor = true;
-        _testConnectionButton.Click += OnTestConnectionButtonClicked;
-        //
-        // _reconnectButton
-        //
-        _reconnectButton.Location = new Point(105, 0);
-        _reconnectButton.Margin = new Padding(0, 0, 3, 0);
-        _reconnectButton.Name = "_reconnectButton";
-        _reconnectButton.Size = new Size(125, 27);
-        _reconnectButton.TabIndex = 1;
-        _reconnectButton.Text = "Переподключить";
-        _reconnectButton.UseVisualStyleBackColor = true;
-        _reconnectButton.Click += OnReconnectButtonClicked;
-        //
-        // _loadScenesButton
-        //
-        _loadScenesButton.Location = new Point(233, 0);
-        _loadScenesButton.Margin = new Padding(0, 0, 3, 0);
-        _loadScenesButton.Name = "_loadScenesButton";
-        _loadScenesButton.Size = new Size(105, 27);
-        _loadScenesButton.TabIndex = 2;
-        _loadScenesButton.Text = "Списки";
-        _loadScenesButton.UseVisualStyleBackColor = true;
-        _loadScenesButton.Click += OnLoadScenesButtonClicked;
-        //
-        // _provisionButton
-        //
-        _provisionButton.Location = new Point(341, 0);
-        _provisionButton.Margin = new Padding(0, 0, 3, 0);
-        _provisionButton.Name = "_provisionButton";
-        _provisionButton.Size = new Size(130, 27);
-        _provisionButton.TabIndex = 3;
-        _provisionButton.Text = "Создать источник";
-        _provisionButton.UseVisualStyleBackColor = true;
-        _provisionButton.Click += OnProvisionButtonClicked;
-        //
-        // _refreshChatNowButton
-        //
-        _refreshChatNowButton.Location = new Point(474, 0);
-        _refreshChatNowButton.Margin = new Padding(0, 0, 3, 0);
-        _refreshChatNowButton.Name = "_refreshChatNowButton";
-        _refreshChatNowButton.Size = new Size(140, 27);
-        _refreshChatNowButton.TabIndex = 4;
-        _refreshChatNowButton.Text = "Обновить чат сейчас";
-        _refreshChatNowButton.UseVisualStyleBackColor = true;
-        _refreshChatNowButton.Click += OnRefreshChatNowButtonClicked;
-        //
-        // _copyUrlButton
-        //
-        _copyUrlButton.Location = new Point(617, 0);
-        _copyUrlButton.Margin = new Padding(0, 0, 3, 0);
-        _copyUrlButton.Name = "_copyUrlButton";
-        _copyUrlButton.Size = new Size(110, 27);
-        _copyUrlButton.TabIndex = 5;
-        _copyUrlButton.Text = "Копировать URL";
-        _copyUrlButton.UseVisualStyleBackColor = true;
-        _copyUrlButton.Click += OnCopyUrlButtonClicked;
+        _hintToolTip.SetToolTip(_sourcesCheckedListBox,
+            "Отметьте аудио-источники OBS для виджета. Пусто = авто-определение микрофона.");
+        _hintToolTip.SetToolTip(_chatRefreshSourcesCheckedListBox,
+            "Выберите Browser Source-источники чата для жёсткого refresh. Пусто = использовать поле \"Источник\".");
         //
         // ObsIntegrationSettingsControl
         //
@@ -604,18 +775,34 @@ partial class ObsIntegrationSettingsControl
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_rootLayout);
         Name = "ObsIntegrationSettingsControl";
-        Size = new Size(600, 732);
+        Size = new Size(600, 560);
         _rootLayout.ResumeLayout(false);
         _rootLayout.PerformLayout();
-        _formLayout.ResumeLayout(false);
-        _formLayout.PerformLayout();
+        _subTabControl.ResumeLayout(false);
+        _connectionTabPage.ResumeLayout(false);
+        _connectionLayout.ResumeLayout(false);
+        _connectionLayout.PerformLayout();
         ((System.ComponentModel.ISupportInitialize)_portNumeric).EndInit();
-        ((System.ComponentModel.ISupportInitialize)_volumeMeterDelayNumeric).EndInit();
+        _connectionButtonPanel.ResumeLayout(false);
+        _browserSourceTabPage.ResumeLayout(false);
+        _browserSourceLayout.ResumeLayout(false);
+        _browserSourceLayout.PerformLayout();
         _sizeFlowPanel.ResumeLayout(false);
         _sizeFlowPanel.PerformLayout();
         ((System.ComponentModel.ISupportInitialize)_widthNumeric).EndInit();
         ((System.ComponentModel.ISupportInitialize)_heightNumeric).EndInit();
-        _buttonPanel.ResumeLayout(false);
+        _browserSourceButtonPanel.ResumeLayout(false);
+        _chatRefreshTabPage.ResumeLayout(false);
+        _chatRefreshLayout.ResumeLayout(false);
+        _chatRefreshLayout.PerformLayout();
+        _chatRefreshButtonPanel.ResumeLayout(false);
+        _dashboardWidgetTabPage.ResumeLayout(false);
+        _dashboardWidgetLayout.ResumeLayout(false);
+        _dashboardWidgetLayout.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)_volumeMeterDelayNumeric).EndInit();
+        _syncTabPage.ResumeLayout(false);
+        _syncLayout.ResumeLayout(false);
+        _syncLayout.PerformLayout();
         ResumeLayout(false);
     }
 
@@ -623,27 +810,25 @@ partial class ObsIntegrationSettingsControl
 
     private TableLayoutPanel _rootLayout;
     private CheckBox _enabledCheckBox;
+    private TabControl _subTabControl;
+    private TabPage _connectionTabPage;
+    private TableLayoutPanel _connectionLayout;
     private CheckBox _autoConnectCheckBox;
-    private CheckBox _autoProvisionCheckBox;
-    private CheckBox _refreshOnStreamStartCheckBox;
-    private CheckBox _syncSceneOnProfileCheckBox;
-    private CheckBox _syncProfileOnSceneCheckBox;
-    private TableLayoutPanel _formLayout;
     private Label _hostLabel;
     private TextBox _hostTextBox;
     private Label _portLabel;
     private NumericUpDown _portNumeric;
     private Label _passwordLabel;
     private TextBox _passwordTextBox;
+    private FlowLayoutPanel _connectionButtonPanel;
+    private Button _testConnectionButton;
+    private Button _reconnectButton;
+    private Button _loadScenesButton;
+    private TabPage _browserSourceTabPage;
+    private TableLayoutPanel _browserSourceLayout;
+    private CheckBox _autoProvisionCheckBox;
     private Label _sceneLabel;
     private ComboBox _sceneComboBox;
-    private Label _sourcesLabel;
-    private CheckedListBox _sourcesCheckedListBox;
-    private Label _chatRefreshSourcesLabel;
-    private CheckedListBox _chatRefreshSourcesCheckedListBox;
-    private ToolTip _hintToolTip;
-    private Label _volumeMeterDelayLabel;
-    private NumericUpDown _volumeMeterDelayNumeric;
     private Label _sourceNameLabel;
     private TextBox _sourceNameTextBox;
     private Label _sizeLabel;
@@ -653,12 +838,26 @@ partial class ObsIntegrationSettingsControl
     private NumericUpDown _heightNumeric;
     private Label _overlayUrlLabel;
     private TextBox _overlayUrlTextBox;
-    private Label _statusLabel;
-    private FlowLayoutPanel _buttonPanel;
-    private Button _testConnectionButton;
-    private Button _reconnectButton;
-    private Button _loadScenesButton;
+    private FlowLayoutPanel _browserSourceButtonPanel;
     private Button _provisionButton;
-    private Button _refreshChatNowButton;
     private Button _copyUrlButton;
+    private TabPage _chatRefreshTabPage;
+    private TableLayoutPanel _chatRefreshLayout;
+    private CheckBox _refreshOnStreamStartCheckBox;
+    private Label _chatRefreshSourcesLabel;
+    private CheckedListBox _chatRefreshSourcesCheckedListBox;
+    private FlowLayoutPanel _chatRefreshButtonPanel;
+    private Button _refreshChatNowButton;
+    private TabPage _dashboardWidgetTabPage;
+    private TableLayoutPanel _dashboardWidgetLayout;
+    private Label _volumeMeterDelayLabel;
+    private NumericUpDown _volumeMeterDelayNumeric;
+    private Label _sourcesLabel;
+    private CheckedListBox _sourcesCheckedListBox;
+    private TabPage _syncTabPage;
+    private TableLayoutPanel _syncLayout;
+    private CheckBox _syncSceneOnProfileCheckBox;
+    private CheckBox _syncProfileOnSceneCheckBox;
+    private Label _statusLabel;
+    private ToolTip _hintToolTip;
 }

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.Designer.cs
@@ -28,6 +28,7 @@ partial class ObsIntegrationSettingsControl
     /// </summary>
     private void InitializeComponent()
     {
+        components = new System.ComponentModel.Container();
         _rootLayout = new TableLayoutPanel();
         _enabledCheckBox = new CheckBox();
         _autoConnectCheckBox = new CheckBox();
@@ -43,8 +44,8 @@ partial class ObsIntegrationSettingsControl
         _passwordTextBox = new TextBox();
         _sceneLabel = new Label();
         _sceneComboBox = new ComboBox();
-        _microphoneLabel = new Label();
-        _microphoneComboBox = new ComboBox();
+        _sourcesLabel = new Label();
+        _sourcesCheckedListBox = new CheckedListBox();
         _volumeMeterDelayLabel = new Label();
         _volumeMeterDelayNumeric = new NumericUpDown();
         _sourceNameLabel = new Label();
@@ -63,6 +64,7 @@ partial class ObsIntegrationSettingsControl
         _loadScenesButton = new Button();
         _provisionButton = new Button();
         _copyUrlButton = new Button();
+        _hintToolTip = new ToolTip(components);
         _rootLayout.SuspendLayout();
         _formLayout.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)_portNumeric).BeginInit();
@@ -95,11 +97,11 @@ partial class ObsIntegrationSettingsControl
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 320F));
+        _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 398F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
         _rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _rootLayout.Size = new Size(600, 536);
+        _rootLayout.Size = new Size(600, 614);
         _rootLayout.TabIndex = 0;
         //
         // _enabledCheckBox
@@ -175,8 +177,8 @@ partial class ObsIntegrationSettingsControl
         _formLayout.Controls.Add(_passwordTextBox, 1, 2);
         _formLayout.Controls.Add(_sceneLabel, 0, 3);
         _formLayout.Controls.Add(_sceneComboBox, 1, 3);
-        _formLayout.Controls.Add(_microphoneLabel, 0, 4);
-        _formLayout.Controls.Add(_microphoneComboBox, 1, 4);
+        _formLayout.Controls.Add(_sourcesLabel, 0, 4);
+        _formLayout.Controls.Add(_sourcesCheckedListBox, 1, 4);
         _formLayout.Controls.Add(_volumeMeterDelayLabel, 0, 5);
         _formLayout.Controls.Add(_volumeMeterDelayNumeric, 1, 5);
         _formLayout.Controls.Add(_sourceNameLabel, 0, 6);
@@ -193,13 +195,13 @@ partial class ObsIntegrationSettingsControl
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
-        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+        _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 110F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
         _formLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _formLayout.Size = new Size(586, 314);
+        _formLayout.Size = new Size(586, 392);
         _formLayout.TabIndex = 5;
         //
         // _hostLabel
@@ -297,29 +299,35 @@ partial class ObsIntegrationSettingsControl
         _sceneComboBox.SelectedIndexChanged += OnSettingChanged;
         _sceneComboBox.TextChanged += OnSettingChanged;
         //
-        // _microphoneLabel
+        // _sourcesLabel
         //
-        _microphoneLabel.AutoSize = true;
-        _microphoneLabel.Dock = DockStyle.Fill;
-        _microphoneLabel.Location = new Point(0, 128);
-        _microphoneLabel.Margin = new Padding(0, 0, 6, 4);
-        _microphoneLabel.Name = "_microphoneLabel";
-        _microphoneLabel.Size = new Size(144, 28);
-        _microphoneLabel.TabIndex = 8;
-        _microphoneLabel.Text = "Микрофон виджета:";
-        _microphoneLabel.TextAlign = ContentAlignment.MiddleLeft;
+        _sourcesLabel.AutoSize = true;
+        _sourcesLabel.Dock = DockStyle.Fill;
+        _sourcesLabel.Location = new Point(0, 128);
+        _sourcesLabel.Margin = new Padding(0, 0, 6, 4);
+        _sourcesLabel.Name = "_sourcesLabel";
+        _sourcesLabel.Size = new Size(144, 106);
+        _sourcesLabel.TabIndex = 8;
+        _sourcesLabel.Text = "Источники виджета:";
+        _sourcesLabel.TextAlign = ContentAlignment.TopLeft;
         //
-        // _microphoneComboBox
+        // _sourcesCheckedListBox
         //
-        _microphoneComboBox.Dock = DockStyle.Fill;
-        _microphoneComboBox.FormattingEnabled = true;
-        _microphoneComboBox.Location = new Point(150, 131);
-        _microphoneComboBox.Margin = new Padding(0, 3, 0, 4);
-        _microphoneComboBox.Name = "_microphoneComboBox";
-        _microphoneComboBox.Size = new Size(436, 23);
-        _microphoneComboBox.TabIndex = 9;
-        _microphoneComboBox.SelectedIndexChanged += OnSettingChanged;
-        _microphoneComboBox.TextChanged += OnSettingChanged;
+        _sourcesCheckedListBox.CheckOnClick = true;
+        _sourcesCheckedListBox.Dock = DockStyle.Fill;
+        _sourcesCheckedListBox.FormattingEnabled = true;
+        _sourcesCheckedListBox.IntegralHeight = false;
+        _sourcesCheckedListBox.Location = new Point(150, 131);
+        _sourcesCheckedListBox.Margin = new Padding(0, 3, 0, 4);
+        _sourcesCheckedListBox.Name = "_sourcesCheckedListBox";
+        _sourcesCheckedListBox.Size = new Size(436, 99);
+        _sourcesCheckedListBox.TabIndex = 9;
+        _sourcesCheckedListBox.ItemCheck += OnSettingChanged;
+        //
+        // _hintToolTip
+        //
+        _hintToolTip.SetToolTip(_sourcesCheckedListBox,
+            "Отметьте аудио-источники OBS для виджета. Пусто = авто-определение микрофона.");
         //
         // _volumeMeterDelayLabel
         //
@@ -455,7 +463,7 @@ partial class ObsIntegrationSettingsControl
         _statusLabel.AutoEllipsis = true;
         _statusLabel.Dock = DockStyle.Fill;
         _statusLabel.ForeColor = Color.Gray;
-        _statusLabel.Location = new Point(7, 408);
+        _statusLabel.Location = new Point(7, 486);
         _statusLabel.Name = "_statusLabel";
         _statusLabel.Size = new Size(586, 30);
         _statusLabel.TabIndex = 6;
@@ -470,7 +478,7 @@ partial class ObsIntegrationSettingsControl
         _buttonPanel.Controls.Add(_provisionButton);
         _buttonPanel.Controls.Add(_copyUrlButton);
         _buttonPanel.Dock = DockStyle.Fill;
-        _buttonPanel.Location = new Point(7, 441);
+        _buttonPanel.Location = new Point(7, 519);
         _buttonPanel.Name = "_buttonPanel";
         _buttonPanel.Size = new Size(586, 28);
         _buttonPanel.TabIndex = 7;
@@ -536,7 +544,7 @@ partial class ObsIntegrationSettingsControl
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_rootLayout);
         Name = "ObsIntegrationSettingsControl";
-        Size = new Size(600, 536);
+        Size = new Size(600, 614);
         _rootLayout.ResumeLayout(false);
         _rootLayout.PerformLayout();
         _formLayout.ResumeLayout(false);
@@ -568,8 +576,9 @@ partial class ObsIntegrationSettingsControl
     private TextBox _passwordTextBox;
     private Label _sceneLabel;
     private ComboBox _sceneComboBox;
-    private Label _microphoneLabel;
-    private ComboBox _microphoneComboBox;
+    private Label _sourcesLabel;
+    private CheckedListBox _sourcesCheckedListBox;
+    private ToolTip _hintToolTip;
     private Label _volumeMeterDelayLabel;
     private NumericUpDown _volumeMeterDelayNumeric;
     private Label _sourceNameLabel;

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.cs
@@ -8,8 +8,6 @@ namespace PoproshaykaBot.WinForms.Forms.Settings;
 
 public sealed partial class ObsIntegrationSettingsControl : UserControl
 {
-    private const string AutoMicrophoneSelectionText = "Авто";
-
     private bool _initialized;
     private bool _loading;
     private int _httpServerPort = 8080;
@@ -44,10 +42,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
             _portNumeric.Value = ClampToNumeric(settings.Port, _portNumeric);
             _passwordTextBox.Text = settings.Password;
             _sceneComboBox.Text = settings.SceneName;
-            PopulateMicrophoneComboBox(string.IsNullOrWhiteSpace(settings.DashboardMicrophoneName)
-                    ? []
-                    : [settings.DashboardMicrophoneName.Trim()],
-                settings.DashboardMicrophoneName);
+            PopulateSourcesCheckedList([], settings.GetDashboardSourceNames());
 
             _volumeMeterDelayNumeric.Value = ClampToNumeric(settings.DashboardVolumeMeterDelayMs, _volumeMeterDelayNumeric);
             _sourceNameTextBox.Text = settings.SourceName;
@@ -77,7 +72,8 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         settings.Port = (int)_portNumeric.Value;
         settings.Password = _passwordTextBox.Text;
         settings.SceneName = _sceneComboBox.Text.Trim();
-        settings.DashboardMicrophoneName = ReadMicrophoneInputNameFromControl();
+        settings.DashboardSourceNames = ReadSourceNamesFromControl();
+        settings.DashboardMicrophoneName = string.Empty;
         settings.DashboardVolumeMeterDelayMs = (int)_volumeMeterDelayNumeric.Value;
         settings.SourceName = string.IsNullOrWhiteSpace(_sourceNameTextBox.Text)
             ? "PoproshaykaBot Chat"
@@ -212,11 +208,6 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         };
     }
 
-    private static string ToMicrophoneSelectionText(string value)
-    {
-        return string.IsNullOrWhiteSpace(value) ? AutoMicrophoneSelectionText : value.Trim();
-    }
-
     private async Task ConnectAndLoadScenesAsync(
         ObsIntegrationSettings settings,
         string successAction,
@@ -269,7 +260,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         try
         {
             PopulateSceneComboBox(scenes);
-            PopulateMicrophoneComboBox(inputNames);
+            PopulateSourcesCheckedList(inputNames, ReadSourceNamesFromControl());
         }
         finally
         {
@@ -293,25 +284,48 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         _sceneComboBox.Text = string.IsNullOrWhiteSpace(current) && scenes.Count > 0 ? scenes[0] : current;
     }
 
-    private void PopulateMicrophoneComboBox(IReadOnlyList<string> inputNames)
+    private void PopulateSourcesCheckedList(IReadOnlyList<string> inputNames, IReadOnlyList<string> selectedNames)
     {
-        PopulateMicrophoneComboBox(inputNames, ReadMicrophoneInputNameFromControl());
+        var selected = selectedNames
+            .Select(name => name?.Trim() ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .ToList();
+
+        var items = inputNames
+            .Select(name => name?.Trim() ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .Concat(selected)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        _sourcesCheckedListBox.BeginUpdate();
+        try
+        {
+            _sourcesCheckedListBox.Items.Clear();
+
+            foreach (var item in items)
+            {
+                var isChecked = selected.Exists(name =>
+                    string.Equals(name, item, StringComparison.OrdinalIgnoreCase));
+
+                _sourcesCheckedListBox.Items.Add(item, isChecked);
+            }
+        }
+        finally
+        {
+            _sourcesCheckedListBox.EndUpdate();
+        }
     }
 
-    private void PopulateMicrophoneComboBox(IReadOnlyList<string> inputNames, string selectedInputName)
+    private List<string> ReadSourceNamesFromControl()
     {
-        _microphoneComboBox.Items.Clear();
-        _microphoneComboBox.Items.Add(AutoMicrophoneSelectionText);
-        _microphoneComboBox.Items.AddRange(inputNames.Cast<object>().ToArray());
-        _microphoneComboBox.Text = ToMicrophoneSelectionText(selectedInputName);
-    }
-
-    private string ReadMicrophoneInputNameFromControl()
-    {
-        var value = _microphoneComboBox.Text.Trim();
-        return string.Equals(value, AutoMicrophoneSelectionText, StringComparison.OrdinalIgnoreCase)
-            ? string.Empty
-            : value;
+        return _sourcesCheckedListBox.CheckedItems
+            .Cast<string>()
+            .Select(name => name.Trim())
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private void ToggleActionButtons(bool enabled)

--- a/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/ObsIntegrationSettingsControl.cs
@@ -36,6 +36,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
             _enabledCheckBox.Checked = settings.Enabled;
             _autoConnectCheckBox.Checked = settings.AutoConnect;
             _autoProvisionCheckBox.Checked = settings.AutoProvisionBrowserSource;
+            _refreshOnStreamStartCheckBox.Checked = settings.RefreshChatSourcesOnStreamStart;
             _syncSceneOnProfileCheckBox.Checked = settings.ApplySceneOnProfile;
             _syncProfileOnSceneCheckBox.Checked = settings.ApplyProfileOnScene;
             _hostTextBox.Text = settings.Host;
@@ -43,6 +44,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
             _passwordTextBox.Text = settings.Password;
             _sceneComboBox.Text = settings.SceneName;
             PopulateSourcesCheckedList([], settings.GetDashboardSourceNames());
+            PopulateChatRefreshSourcesCheckedList([], settings.ChatRefreshSources);
 
             _volumeMeterDelayNumeric.Value = ClampToNumeric(settings.DashboardVolumeMeterDelayMs, _volumeMeterDelayNumeric);
             _sourceNameTextBox.Text = settings.SourceName;
@@ -66,6 +68,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         settings.Enabled = _enabledCheckBox.Checked;
         settings.AutoConnect = _autoConnectCheckBox.Checked;
         settings.AutoProvisionBrowserSource = _autoProvisionCheckBox.Checked;
+        settings.RefreshChatSourcesOnStreamStart = _refreshOnStreamStartCheckBox.Checked;
         settings.ApplySceneOnProfile = _syncSceneOnProfileCheckBox.Checked;
         settings.ApplyProfileOnScene = _syncProfileOnSceneCheckBox.Checked;
         settings.Host = string.IsNullOrWhiteSpace(_hostTextBox.Text) ? "127.0.0.1" : _hostTextBox.Text.Trim();
@@ -81,6 +84,7 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
 
         settings.Width = (int)_widthNumeric.Value;
         settings.Height = (int)_heightNumeric.Value;
+        settings.ChatRefreshSources = ReadChatRefreshSourceNamesFromControl();
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -174,6 +178,20 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
         });
     }
 
+    private void OnRefreshChatNowButtonClicked(object? sender, EventArgs e)
+    {
+        StartObsOperation(async ct =>
+        {
+            var settings = ReadSettingsFromControls();
+            var refreshed = await ObsIntegration.RefreshConfiguredChatSourcesAsync(settings, ct);
+
+            SetStatus(refreshed > 0
+                    ? $"● Обновлено чат-источников: {refreshed}"
+                    : "● Нет настроенных чат-источников",
+                refreshed > 0 ? Color.Green : Color.DarkOrange);
+        });
+    }
+
     private void OnCopyUrlButtonClicked(object? sender, EventArgs e)
     {
         try
@@ -255,12 +273,14 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
     {
         var scenes = await ObsIntegration.ListScenesAsync(settings, cancellationToken);
         var inputNames = await ObsIntegration.ListInputNamesAsync(settings, cancellationToken);
+        var browserSourceNames = await ObsIntegration.ListBrowserSourceNamesAsync(settings, cancellationToken);
 
         _loading = true;
         try
         {
             PopulateSceneComboBox(scenes);
             PopulateSourcesCheckedList(inputNames, ReadSourceNamesFromControl());
+            PopulateChatRefreshSourcesCheckedList(browserSourceNames, ReadChatRefreshSourceNamesFromControl());
         }
         finally
         {
@@ -328,12 +348,57 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
             .ToList();
     }
 
+    private void PopulateChatRefreshSourcesCheckedList(IReadOnlyList<string> browserSourceNames, IReadOnlyList<string> selectedNames)
+    {
+        var selected = selectedNames
+            .Select(name => name?.Trim() ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .ToList();
+
+        var items = browserSourceNames
+            .Select(name => name?.Trim() ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .Concat(selected)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        _chatRefreshSourcesCheckedListBox.BeginUpdate();
+        try
+        {
+            _chatRefreshSourcesCheckedListBox.Items.Clear();
+
+            foreach (var item in items)
+            {
+                var isChecked = selected.Exists(name =>
+                    string.Equals(name, item, StringComparison.OrdinalIgnoreCase));
+
+                _chatRefreshSourcesCheckedListBox.Items.Add(item, isChecked);
+            }
+        }
+        finally
+        {
+            _chatRefreshSourcesCheckedListBox.EndUpdate();
+        }
+    }
+
+    private List<string> ReadChatRefreshSourceNamesFromControl()
+    {
+        return _chatRefreshSourcesCheckedListBox.CheckedItems
+            .Cast<string>()
+            .Select(name => name.Trim())
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private void ToggleActionButtons(bool enabled)
     {
         _testConnectionButton.Enabled = enabled;
         _reconnectButton.Enabled = enabled && _enabledCheckBox.Checked;
         _loadScenesButton.Enabled = enabled;
         _provisionButton.Enabled = enabled && _enabledCheckBox.Checked;
+        _refreshChatNowButton.Enabled = enabled && _enabledCheckBox.Checked;
         _copyUrlButton.Enabled = enabled;
     }
 
@@ -341,10 +406,12 @@ public sealed partial class ObsIntegrationSettingsControl : UserControl
     {
         _autoConnectCheckBox.Enabled = _enabledCheckBox.Checked;
         _autoProvisionCheckBox.Enabled = _enabledCheckBox.Checked;
+        _refreshOnStreamStartCheckBox.Enabled = _enabledCheckBox.Checked;
         _syncSceneOnProfileCheckBox.Enabled = _enabledCheckBox.Checked;
         _syncProfileOnSceneCheckBox.Enabled = _enabledCheckBox.Checked;
         _reconnectButton.Enabled = _enabledCheckBox.Checked;
         _provisionButton.Enabled = _enabledCheckBox.Checked;
+        _refreshChatNowButton.Enabled = _enabledCheckBox.Checked;
     }
 
     private void UpdateOverlayUrl()

--- a/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.Designer.cs
@@ -57,6 +57,8 @@ partial class SettingsForm
         _dashboardSettingsControl = new DashboardSettingsControl();
         _miscTabPage = new TabPage();
         _miscSettingsControl = new MiscSettingsControl();
+        _updateTabPage = new TabPage();
+        _updateSettingsControl = new UpdateSettingsControl();
         _buttonPanel = new FlowLayoutPanel();
         _resetButton = new Button();
         _okButton = new Button();
@@ -78,6 +80,7 @@ partial class SettingsForm
         _pollsTabPage.SuspendLayout();
         _dashboardTabPage.SuspendLayout();
         _miscTabPage.SuspendLayout();
+        _updateTabPage.SuspendLayout();
         _buttonPanel.SuspendLayout();
         SuspendLayout();
         // 
@@ -109,6 +112,7 @@ partial class SettingsForm
         _tabControl.Controls.Add(_pollsTabPage);
         _tabControl.Controls.Add(_dashboardTabPage);
         _tabControl.Controls.Add(_miscTabPage);
+        _tabControl.Controls.Add(_updateTabPage);
         _tabControl.Dock = DockStyle.Fill;
         _tabControl.Location = new Point(15, 15);
         _tabControl.Name = "_tabControl";
@@ -397,8 +401,29 @@ partial class SettingsForm
         _miscSettingsControl.Size = new Size(593, 529);
         _miscSettingsControl.TabIndex = 0;
         //
+        // _updateTabPage
+        //
+        _updateTabPage.Controls.Add(_updateSettingsControl);
+        _updateTabPage.Location = new Point(4, 24);
+        _updateTabPage.Name = "_updateTabPage";
+        _updateTabPage.Padding = new Padding(10, 10, 10, 10);
+        _updateTabPage.Size = new Size(613, 549);
+        _updateTabPage.TabIndex = 12;
+        _updateTabPage.Text = "Обновления";
+        _updateTabPage.UseVisualStyleBackColor = true;
+        //
+        // _updateSettingsControl
+        //
+        _updateSettingsControl.Dock = DockStyle.Fill;
+        _updateSettingsControl.Location = new Point(10, 10);
+        _updateSettingsControl.Margin = new Padding(6, 7, 6, 7);
+        _updateSettingsControl.Name = "_updateSettingsControl";
+        _updateSettingsControl.Size = new Size(593, 529);
+        _updateSettingsControl.TabIndex = 0;
+        _updateSettingsControl.SettingChanged += OnSettingChanged;
+        //
         // _buttonPanel
-        // 
+        //
         _buttonPanel.AutoSize = true;
         _buttonPanel.Controls.Add(_resetButton);
         _buttonPanel.Controls.Add(_okButton);
@@ -490,6 +515,7 @@ partial class SettingsForm
         _pollsTabPage.ResumeLayout(false);
         _dashboardTabPage.ResumeLayout(false);
         _miscTabPage.ResumeLayout(false);
+        _updateTabPage.ResumeLayout(false);
         _buttonPanel.ResumeLayout(false);
         ResumeLayout(false);
     }
@@ -520,6 +546,8 @@ partial class SettingsForm
     private AutoBroadcastSettingsControl _autoBroadcastSettingsControl;
     private BotLifecycleAutomationSettingsControl _botLifecycleAutomationSettingsControl;
     private MiscSettingsControl _miscSettingsControl;
+    private TabPage _updateTabPage;
+    private UpdateSettingsControl _updateSettingsControl;
     private TabPage _pollsTabPage;
     private PollsSettingsControl _pollsSettingsControl;
     private TabPage _dashboardTabPage;

--- a/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
@@ -7,6 +7,7 @@ using PoproshaykaBot.Core.Settings;
 using PoproshaykaBot.Core.Settings.Obs;
 using PoproshaykaBot.Core.Settings.Stores;
 using PoproshaykaBot.Core.Settings.Ui;
+using PoproshaykaBot.Core.Settings.Update;
 using PoproshaykaBot.Core.Twitch.Auth;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 
@@ -20,6 +21,7 @@ public partial class SettingsForm : Form
     private readonly ObsIntegrationStore _obsIntegrationStore;
     private readonly DashboardLayoutStore _dashboardLayoutStore;
     private readonly PollsStore _pollsStore;
+    private readonly UpdateStore _updateStore;
     private readonly IEventBus _eventBus;
     private readonly KestrelHttpServer _kestrelHttpServer;
     private readonly ILogger<SettingsForm> _logger;
@@ -30,6 +32,7 @@ public partial class SettingsForm : Form
     private ObsChatSettings _obsChatDraft;
     private ObsIntegrationSettings _obsIntegrationDraft;
     private PollsSettings _pollsDraft;
+    private UpdateSettings _updateDraft;
     private DashboardLayoutSettings? _dashboardDraft;
     private bool _initialized;
     private bool _hasChanges;
@@ -41,6 +44,7 @@ public partial class SettingsForm : Form
         ObsIntegrationStore obsIntegrationStore,
         DashboardLayoutStore dashboardLayoutStore,
         PollsStore pollsStore,
+        UpdateStore updateStore,
         IEventBus eventBus,
         KestrelHttpServer kestrelHttpServer,
         ILogger<SettingsForm> logger)
@@ -51,6 +55,7 @@ public partial class SettingsForm : Form
         _obsIntegrationStore = obsIntegrationStore;
         _dashboardLayoutStore = dashboardLayoutStore;
         _pollsStore = pollsStore;
+        _updateStore = updateStore;
         _eventBus = eventBus;
         _kestrelHttpServer = kestrelHttpServer;
         _logger = logger;
@@ -61,6 +66,7 @@ public partial class SettingsForm : Form
         _obsChatDraft = JsonStoreClone.DeepClone(obsChatStore.Load());
         _obsIntegrationDraft = JsonStoreClone.DeepClone(obsIntegrationStore.Load());
         _pollsDraft = JsonStoreClone.DeepClone(pollsStore.Load());
+        _updateDraft = JsonStoreClone.DeepClone(updateStore.Load());
         _dashboardDraft = JsonStoreClone.DeepCloneNullable(dashboardLayoutStore.LoadDashboard());
 
         InitializeComponent();
@@ -92,6 +98,8 @@ public partial class SettingsForm : Form
                 () => _miscSettingsControl.SaveSettings(_settings)),
             new(() => _pollsSettingsControl.LoadSettings(_pollsDraft),
                 () => _pollsSettingsControl.SaveSettings(_pollsDraft)),
+            new(() => _updateSettingsControl.LoadSettings(_updateDraft),
+                () => _updateSettingsControl.SaveSettings(_updateDraft)),
             new(() => _dashboardSettingsControl.LoadSettings(_dashboardDraft),
                 () => _dashboardDraft = _dashboardSettingsControl.SaveSettings()),
         ];
@@ -198,6 +206,7 @@ public partial class SettingsForm : Form
         _obsChatDraft = new();
         _obsIntegrationDraft = new();
         _pollsDraft = new();
+        _updateDraft = new();
         _dashboardDraft = null;
 
         LoadSettingsToControls();
@@ -256,6 +265,7 @@ public partial class SettingsForm : Form
             _obsChatStore.Save(_obsChatDraft);
             _obsIntegrationStore.Save(_obsIntegrationDraft);
             _pollsStore.Save(_pollsDraft);
+            _updateStore.Save(_updateDraft);
 
             if (_dashboardDraft != null)
             {

--- a/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
@@ -86,7 +86,7 @@ public partial class SettingsForm : Form
                 }),
             new(() => _oauthSettingsControl.LoadSettings(_settings, _botDraft, _broadcasterDraft),
                 () => _oauthSettingsControl.SaveSettings(_settings)),
-            new(() => _obsChatSettingsControl.LoadSettings(_obsChatDraft),
+            new(() => _obsChatSettingsControl.LoadSettings(_obsChatDraft, _settings.Twitch.HttpServerPort),
                 () => _obsChatSettingsControl.SaveSettings(_obsChatDraft)),
             new(() => _obsIntegrationSettingsControl.LoadSettings(_obsIntegrationDraft, _settings.Twitch.HttpServerPort),
                 () => _obsIntegrationSettingsControl.SaveSettings(_obsIntegrationDraft)),

--- a/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/SettingsForm.cs
@@ -10,6 +10,7 @@ using PoproshaykaBot.Core.Settings.Ui;
 using PoproshaykaBot.Core.Settings.Update;
 using PoproshaykaBot.Core.Twitch.Auth;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
+using System.Text.Json;
 
 namespace PoproshaykaBot.WinForms.Forms.Settings;
 
@@ -30,6 +31,7 @@ public partial class SettingsForm : Form
     private TwitchAccountSettings _botDraft;
     private TwitchAccountSettings _broadcasterDraft;
     private ObsChatSettings _obsChatDraft;
+    private string _obsChatBaselineJson;
     private ObsIntegrationSettings _obsIntegrationDraft;
     private PollsSettings _pollsDraft;
     private UpdateSettings _updateDraft;
@@ -64,6 +66,7 @@ public partial class SettingsForm : Form
         _botDraft = JsonStoreClone.DeepClone(accountsStore.LoadBot());
         _broadcasterDraft = JsonStoreClone.DeepClone(accountsStore.LoadBroadcaster());
         _obsChatDraft = JsonStoreClone.DeepClone(obsChatStore.Load());
+        _obsChatBaselineJson = SerializeObsChat(_obsChatDraft);
         _obsIntegrationDraft = JsonStoreClone.DeepClone(obsIntegrationStore.Load());
         _pollsDraft = JsonStoreClone.DeepClone(pollsStore.Load());
         _updateDraft = JsonStoreClone.DeepClone(updateStore.Load());
@@ -214,6 +217,11 @@ public partial class SettingsForm : Form
         UpdateButtonStates();
     }
 
+    private static string SerializeObsChat(ObsChatSettings settings)
+    {
+        return JsonSerializer.Serialize(settings, JsonStoreOptions.Default);
+    }
+
     private void FlushDraftFromControls(AppSettings settings)
     {
         _basicSettingsControl.SaveSettings(settings.Twitch);
@@ -239,6 +247,40 @@ public partial class SettingsForm : Form
         }
     }
 
+    private void SaveObsChatDraftWithConflictCheck()
+    {
+        var current = _obsChatStore.Load();
+        var currentJson = SerializeObsChat(current);
+
+        if (!string.Equals(currentJson, _obsChatBaselineJson, StringComparison.Ordinal))
+        {
+            var answer = MessageBox.Show(this,
+                """
+                Настройки чат-оверлея были изменены извне (например, через демо-страницу) уже после открытия этого окна.
+
+                Перезаписать их значениями из этого окна?
+
+                «Да» — применить значения из этого окна.
+                «Нет» — оставить внешние изменения, не трогая вкладку «OBS Чат».
+                """,
+                "Конфликт настроек чат-оверлея",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning,
+                MessageBoxDefaultButton.Button2);
+
+            if (answer != DialogResult.Yes)
+            {
+                _obsChatDraft = JsonStoreClone.DeepClone(current);
+                _obsChatSettingsControl.LoadSettings(_obsChatDraft, _settings.Twitch.HttpServerPort);
+                _obsChatBaselineJson = currentJson;
+                return;
+            }
+        }
+
+        _obsChatStore.Save(_obsChatDraft);
+        _obsChatBaselineJson = SerializeObsChat(_obsChatDraft);
+    }
+
     private void UpdateButtonStates()
     {
         _applyButton.Enabled = _hasChanges;
@@ -262,7 +304,7 @@ public partial class SettingsForm : Form
 
             _settingsManager.SaveSettings(_settings);
             _accountsStore.SaveAll(_botDraft, _broadcasterDraft);
-            _obsChatStore.Save(_obsChatDraft);
+            SaveObsChatDraftWithConflictCheck();
             _obsIntegrationStore.Save(_obsIntegrationDraft);
             _pollsStore.Save(_pollsDraft);
             _updateStore.Save(_updateDraft);

--- a/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.Designer.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.Designer.cs
@@ -1,0 +1,344 @@
+﻿namespace PoproshaykaBot.WinForms.Forms.Settings
+{
+    partial class UpdateSettingsControl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            _mainTableLayout = new TableLayoutPanel();
+            _statusGroupBox = new GroupBox();
+            _statusTableLayout = new TableLayoutPanel();
+            _currentVersionLabel = new Label();
+            _statusLabel = new Label();
+            _parametersGroupBox = new GroupBox();
+            _parametersTableLayout = new TableLayoutPanel();
+            _autoCheckCheckBox = new CheckBox();
+            _intervalLabel = new Label();
+            _intervalNumeric = new NumericUpDown();
+            _autoInstallCheckBox = new CheckBox();
+            _allowFrameworkDependentCheckBox = new CheckBox();
+            _repositoryLabel = new Label();
+            _repositoryTextBox = new TextBox();
+            _repositoryHintLabel = new Label();
+            _actionsGroupBox = new GroupBox();
+            _actionsTableLayout = new TableLayoutPanel();
+            _checkNowButton = new Button();
+            _installButton = new Button();
+            _mainTableLayout.SuspendLayout();
+            _statusGroupBox.SuspendLayout();
+            _statusTableLayout.SuspendLayout();
+            _parametersGroupBox.SuspendLayout();
+            _parametersTableLayout.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)_intervalNumeric).BeginInit();
+            _actionsGroupBox.SuspendLayout();
+            _actionsTableLayout.SuspendLayout();
+            SuspendLayout();
+            //
+            // _mainTableLayout
+            //
+            _mainTableLayout.ColumnCount = 1;
+            _mainTableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _mainTableLayout.Controls.Add(_statusGroupBox, 0, 0);
+            _mainTableLayout.Controls.Add(_parametersGroupBox, 0, 1);
+            _mainTableLayout.Controls.Add(_actionsGroupBox, 0, 2);
+            _mainTableLayout.Dock = DockStyle.Fill;
+            _mainTableLayout.Location = new Point(0, 0);
+            _mainTableLayout.Name = "_mainTableLayout";
+            _mainTableLayout.RowCount = 4;
+            _mainTableLayout.RowStyles.Add(new RowStyle());
+            _mainTableLayout.RowStyles.Add(new RowStyle());
+            _mainTableLayout.RowStyles.Add(new RowStyle());
+            _mainTableLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            _mainTableLayout.Size = new Size(593, 529);
+            _mainTableLayout.TabIndex = 0;
+            //
+            // _statusGroupBox
+            //
+            _statusGroupBox.AutoSize = true;
+            _statusGroupBox.Controls.Add(_statusTableLayout);
+            _statusGroupBox.Dock = DockStyle.Fill;
+            _statusGroupBox.Location = new Point(3, 3);
+            _statusGroupBox.Name = "_statusGroupBox";
+            _statusGroupBox.Padding = new Padding(10);
+            _statusGroupBox.Size = new Size(587, 75);
+            _statusGroupBox.TabIndex = 0;
+            _statusGroupBox.TabStop = false;
+            _statusGroupBox.Text = "Состояние";
+            //
+            // _statusTableLayout
+            //
+            _statusTableLayout.AutoSize = true;
+            _statusTableLayout.ColumnCount = 1;
+            _statusTableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _statusTableLayout.Controls.Add(_currentVersionLabel, 0, 0);
+            _statusTableLayout.Controls.Add(_statusLabel, 0, 1);
+            _statusTableLayout.Dock = DockStyle.Fill;
+            _statusTableLayout.Location = new Point(10, 26);
+            _statusTableLayout.Name = "_statusTableLayout";
+            _statusTableLayout.RowCount = 2;
+            _statusTableLayout.RowStyles.Add(new RowStyle());
+            _statusTableLayout.RowStyles.Add(new RowStyle());
+            _statusTableLayout.Size = new Size(567, 39);
+            _statusTableLayout.TabIndex = 0;
+            //
+            // _currentVersionLabel
+            //
+            _currentVersionLabel.Anchor = AnchorStyles.Left;
+            _currentVersionLabel.AutoSize = true;
+            _currentVersionLabel.Name = "_currentVersionLabel";
+            _currentVersionLabel.TabIndex = 0;
+            _currentVersionLabel.Text = "Текущая версия:";
+            //
+            // _statusLabel
+            //
+            _statusLabel.Anchor = AnchorStyles.Left;
+            _statusLabel.AutoSize = true;
+            _statusLabel.ForeColor = Color.Gray;
+            _statusLabel.Name = "_statusLabel";
+            _statusLabel.TabIndex = 1;
+            _statusLabel.Text = "Проверка обновлений ещё не выполнялась.";
+            //
+            // _parametersGroupBox
+            //
+            _parametersGroupBox.AutoSize = true;
+            _parametersGroupBox.Controls.Add(_parametersTableLayout);
+            _parametersGroupBox.Dock = DockStyle.Fill;
+            _parametersGroupBox.Location = new Point(3, 84);
+            _parametersGroupBox.Name = "_parametersGroupBox";
+            _parametersGroupBox.Padding = new Padding(10);
+            _parametersGroupBox.Size = new Size(587, 113);
+            _parametersGroupBox.TabIndex = 1;
+            _parametersGroupBox.TabStop = false;
+            _parametersGroupBox.Text = "Параметры";
+            //
+            // _parametersTableLayout
+            //
+            _parametersTableLayout.AutoSize = true;
+            _parametersTableLayout.ColumnCount = 2;
+            _parametersTableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _parametersTableLayout.ColumnStyles.Add(new ColumnStyle());
+            _parametersTableLayout.Controls.Add(_autoCheckCheckBox, 0, 0);
+            _parametersTableLayout.Controls.Add(_intervalLabel, 0, 1);
+            _parametersTableLayout.Controls.Add(_intervalNumeric, 1, 1);
+            _parametersTableLayout.Controls.Add(_autoInstallCheckBox, 0, 2);
+            _parametersTableLayout.Controls.Add(_allowFrameworkDependentCheckBox, 0, 3);
+            _parametersTableLayout.Controls.Add(_repositoryLabel, 0, 4);
+            _parametersTableLayout.Controls.Add(_repositoryTextBox, 0, 5);
+            _parametersTableLayout.Controls.Add(_repositoryHintLabel, 0, 6);
+            _parametersTableLayout.Dock = DockStyle.Fill;
+            _parametersTableLayout.Location = new Point(10, 26);
+            _parametersTableLayout.Name = "_parametersTableLayout";
+            _parametersTableLayout.RowCount = 7;
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.RowStyles.Add(new RowStyle());
+            _parametersTableLayout.Size = new Size(567, 170);
+            _parametersTableLayout.TabIndex = 0;
+            //
+            // _autoCheckCheckBox
+            //
+            _autoCheckCheckBox.Anchor = AnchorStyles.Left;
+            _autoCheckCheckBox.AutoSize = true;
+            _parametersTableLayout.SetColumnSpan(_autoCheckCheckBox, 2);
+            _autoCheckCheckBox.Name = "_autoCheckCheckBox";
+            _autoCheckCheckBox.TabIndex = 0;
+            _autoCheckCheckBox.Text = "Проверять обновления автоматически";
+            _autoCheckCheckBox.UseVisualStyleBackColor = true;
+            _autoCheckCheckBox.CheckedChanged += OnSettingChanged;
+            //
+            // _intervalLabel
+            //
+            _intervalLabel.Anchor = AnchorStyles.Left;
+            _intervalLabel.AutoSize = true;
+            _intervalLabel.Name = "_intervalLabel";
+            _intervalLabel.TabIndex = 1;
+            _intervalLabel.Text = "Интервал проверки (часов):";
+            //
+            // _intervalNumeric
+            //
+            _intervalNumeric.Anchor = AnchorStyles.Left;
+            _intervalNumeric.Maximum = new decimal(new int[] { 168, 0, 0, 0 });
+            _intervalNumeric.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            _intervalNumeric.Name = "_intervalNumeric";
+            _intervalNumeric.TabIndex = 2;
+            _intervalNumeric.Value = new decimal(new int[] { 6, 0, 0, 0 });
+            _intervalNumeric.ValueChanged += OnSettingChanged;
+            //
+            // _autoInstallCheckBox
+            //
+            _autoInstallCheckBox.Anchor = AnchorStyles.Left;
+            _autoInstallCheckBox.AutoSize = true;
+            _parametersTableLayout.SetColumnSpan(_autoInstallCheckBox, 2);
+            _autoInstallCheckBox.Name = "_autoInstallCheckBox";
+            _autoInstallCheckBox.TabIndex = 3;
+            _autoInstallCheckBox.Text = "Устанавливать обновление автоматически при выходе из приложения";
+            _autoInstallCheckBox.UseVisualStyleBackColor = true;
+            _autoInstallCheckBox.CheckedChanged += OnSettingChanged;
+            //
+            // _allowFrameworkDependentCheckBox
+            //
+            _allowFrameworkDependentCheckBox.Anchor = AnchorStyles.Left;
+            _allowFrameworkDependentCheckBox.AutoSize = true;
+            _parametersTableLayout.SetColumnSpan(_allowFrameworkDependentCheckBox, 2);
+            _allowFrameworkDependentCheckBox.Name = "_allowFrameworkDependentCheckBox";
+            _allowFrameworkDependentCheckBox.TabIndex = 4;
+            _allowFrameworkDependentCheckBox.Text = "Разрешить автообновление для сборки, требующей .NET (framework-dependent)";
+            _allowFrameworkDependentCheckBox.UseVisualStyleBackColor = true;
+            _allowFrameworkDependentCheckBox.Visible = false;
+            _allowFrameworkDependentCheckBox.CheckedChanged += OnAllowFrameworkDependentChanged;
+            //
+            // _repositoryLabel
+            //
+            _repositoryLabel.Anchor = AnchorStyles.Left;
+            _repositoryLabel.AutoSize = true;
+            _parametersTableLayout.SetColumnSpan(_repositoryLabel, 2);
+            _repositoryLabel.Margin = new Padding(3, 8, 3, 0);
+            _repositoryLabel.Name = "_repositoryLabel";
+            _repositoryLabel.TabIndex = 5;
+            _repositoryLabel.Text = "Репозиторий обновлений (owner/repo):";
+            //
+            // _repositoryTextBox
+            //
+            _repositoryTextBox.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            _parametersTableLayout.SetColumnSpan(_repositoryTextBox, 2);
+            _repositoryTextBox.Name = "_repositoryTextBox";
+            _repositoryTextBox.TabIndex = 6;
+            _repositoryTextBox.TextChanged += OnRepositoryTextChanged;
+            //
+            // _repositoryHintLabel
+            //
+            _repositoryHintLabel.Anchor = AnchorStyles.Left;
+            _repositoryHintLabel.AutoSize = true;
+            _parametersTableLayout.SetColumnSpan(_repositoryHintLabel, 2);
+            _repositoryHintLabel.ForeColor = Color.Gray;
+            _repositoryHintLabel.Name = "_repositoryHintLabel";
+            _repositoryHintLabel.TabIndex = 7;
+            //
+            // _actionsGroupBox
+            //
+            _actionsGroupBox.AutoSize = true;
+            _actionsGroupBox.Controls.Add(_actionsTableLayout);
+            _actionsGroupBox.Dock = DockStyle.Fill;
+            _actionsGroupBox.Location = new Point(3, 203);
+            _actionsGroupBox.Name = "_actionsGroupBox";
+            _actionsGroupBox.Padding = new Padding(10);
+            _actionsGroupBox.Size = new Size(587, 75);
+            _actionsGroupBox.TabIndex = 2;
+            _actionsGroupBox.TabStop = false;
+            _actionsGroupBox.Text = "Действия";
+            //
+            // _actionsTableLayout
+            //
+            _actionsTableLayout.AutoSize = true;
+            _actionsTableLayout.ColumnCount = 3;
+            _actionsTableLayout.ColumnStyles.Add(new ColumnStyle());
+            _actionsTableLayout.ColumnStyles.Add(new ColumnStyle());
+            _actionsTableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _actionsTableLayout.Controls.Add(_checkNowButton, 0, 0);
+            _actionsTableLayout.Controls.Add(_installButton, 1, 0);
+            _actionsTableLayout.Dock = DockStyle.Fill;
+            _actionsTableLayout.Location = new Point(10, 26);
+            _actionsTableLayout.Name = "_actionsTableLayout";
+            _actionsTableLayout.RowCount = 1;
+            _actionsTableLayout.RowStyles.Add(new RowStyle());
+            _actionsTableLayout.Size = new Size(567, 39);
+            _actionsTableLayout.TabIndex = 0;
+            //
+            // _checkNowButton
+            //
+            _checkNowButton.AutoSize = true;
+            _checkNowButton.MinimumSize = new Size(92, 0);
+            _checkNowButton.Name = "_checkNowButton";
+            _checkNowButton.TabIndex = 0;
+            _checkNowButton.Text = "🔄 Проверить сейчас";
+            _checkNowButton.UseVisualStyleBackColor = true;
+            _checkNowButton.Click += OnCheckNowButtonClicked;
+            //
+            // _installButton
+            //
+            _installButton.AutoSize = true;
+            _installButton.Enabled = false;
+            _installButton.Margin = new Padding(6, 3, 3, 3);
+            _installButton.MinimumSize = new Size(92, 0);
+            _installButton.Name = "_installButton";
+            _installButton.TabIndex = 1;
+            _installButton.Text = "⬇️ Установить обновление";
+            _installButton.UseVisualStyleBackColor = true;
+            _installButton.Click += OnInstallButtonClicked;
+            //
+            // UpdateSettingsControl
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(_mainTableLayout);
+            Name = "UpdateSettingsControl";
+            Size = new Size(593, 529);
+            _mainTableLayout.ResumeLayout(false);
+            _mainTableLayout.PerformLayout();
+            _statusGroupBox.ResumeLayout(false);
+            _statusGroupBox.PerformLayout();
+            _statusTableLayout.ResumeLayout(false);
+            _statusTableLayout.PerformLayout();
+            _parametersGroupBox.ResumeLayout(false);
+            _parametersGroupBox.PerformLayout();
+            _parametersTableLayout.ResumeLayout(false);
+            _parametersTableLayout.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)_intervalNumeric).EndInit();
+            _actionsGroupBox.ResumeLayout(false);
+            _actionsGroupBox.PerformLayout();
+            _actionsTableLayout.ResumeLayout(false);
+            _actionsTableLayout.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private TableLayoutPanel _mainTableLayout;
+        private GroupBox _statusGroupBox;
+        private TableLayoutPanel _statusTableLayout;
+        private Label _currentVersionLabel;
+        private Label _statusLabel;
+        private GroupBox _parametersGroupBox;
+        private TableLayoutPanel _parametersTableLayout;
+        private CheckBox _autoCheckCheckBox;
+        private Label _intervalLabel;
+        private NumericUpDown _intervalNumeric;
+        private CheckBox _autoInstallCheckBox;
+        private CheckBox _allowFrameworkDependentCheckBox;
+        private Label _repositoryLabel;
+        private TextBox _repositoryTextBox;
+        private Label _repositoryHintLabel;
+        private GroupBox _actionsGroupBox;
+        private TableLayoutPanel _actionsTableLayout;
+        private Button _checkNowButton;
+        private Button _installButton;
+    }
+}

--- a/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.cs
+++ b/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.cs
@@ -1,0 +1,280 @@
+﻿using PoproshaykaBot.Core.Infrastructure.Events;
+using PoproshaykaBot.Core.Infrastructure.Events.Update;
+using PoproshaykaBot.Core.Settings.Update;
+using PoproshaykaBot.Core.Update;
+using PoproshaykaBot.WinForms.Infrastructure.Di;
+using System.Globalization;
+
+namespace PoproshaykaBot.WinForms.Forms.Settings;
+
+public sealed partial class UpdateSettingsControl : UserControl
+{
+    private readonly List<IDisposable> _subs = [];
+    private bool _initialized;
+    private bool _busy;
+
+    public UpdateSettingsControl()
+    {
+        InitializeComponent();
+    }
+
+    public event EventHandler? SettingChanged;
+
+    [Inject]
+    public IUpdateCoordinator Updates { get; internal init; } = null!;
+
+    [Inject]
+    public IEventBus Bus { get; internal init; } = null!;
+
+    public void LoadSettings(UpdateSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        _autoCheckCheckBox.Checked = settings.AutoCheckEnabled;
+        _intervalNumeric.Value = Math.Clamp(settings.CheckIntervalHours, (int)_intervalNumeric.Minimum, (int)_intervalNumeric.Maximum);
+        _autoInstallCheckBox.Checked = settings.ApplyMode == UpdateApplyMode.SilentOnExit;
+        _allowFrameworkDependentCheckBox.Checked = settings.AllowFrameworkDependentUpdate;
+        _allowFrameworkDependentCheckBox.Visible = Updates.Kind == UpdateKind.FrameworkDependent;
+        _repositoryTextBox.PlaceholderText = Updates.DefaultRepositorySlug;
+        _repositoryTextBox.Text = settings.RepositoryOverride ?? string.Empty;
+
+        RefreshRepositoryHint();
+        RefreshStatus(settings);
+    }
+
+    public void SaveSettings(UpdateSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        settings.AutoCheckEnabled = _autoCheckCheckBox.Checked;
+        settings.CheckIntervalHours = (int)_intervalNumeric.Value;
+        settings.ApplyMode = _autoInstallCheckBox.Checked ? UpdateApplyMode.SilentOnExit : UpdateApplyMode.NotifyAndConfirm;
+        settings.AllowFrameworkDependentUpdate = _allowFrameworkDependentCheckBox.Checked;
+
+        var repository = _repositoryTextBox.Text.Trim();
+        settings.RepositoryOverride = repository.Length == 0 ? null : repository;
+    }
+
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+
+        if (_initialized)
+        {
+            return;
+        }
+
+        if (this.IsInDesignMode())
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        _subs.Add(Bus.SubscribeOnUi<UpdateAvailable>(this, _ => RefreshStatus(null)));
+        _subs.DisposeOnClose(this);
+    }
+
+    private void OnSettingChanged(object? sender, EventArgs e)
+    {
+        SettingChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnAllowFrameworkDependentChanged(object? sender, EventArgs e)
+    {
+        SettingChanged?.Invoke(this, EventArgs.Empty);
+        RefreshStatus(null);
+    }
+
+    private void OnRepositoryTextChanged(object? sender, EventArgs e)
+    {
+        SettingChanged?.Invoke(this, EventArgs.Empty);
+        RefreshRepositoryHint();
+    }
+
+    private async void OnCheckNowButtonClicked(object? sender, EventArgs e)
+    {
+        if (_busy)
+        {
+            return;
+        }
+
+        SetBusy(true);
+        _statusLabel.ForeColor = Color.Blue;
+        _statusLabel.Text = "Проверка обновлений…";
+
+        try
+        {
+            var candidate = await Updates.CheckNowAsync(CancellationToken.None);
+
+            if (candidate is null)
+            {
+                _statusLabel.ForeColor = Color.Gray;
+                _statusLabel.Text = "У вас установлена актуальная версия.";
+            }
+            else
+            {
+                RefreshStatus(null);
+            }
+        }
+        catch (Exception exception)
+        {
+            _statusLabel.ForeColor = Color.Red;
+            _statusLabel.Text = $"Ошибка проверки: {exception.Message}";
+        }
+        finally
+        {
+            SetBusy(false);
+        }
+    }
+
+    private async void OnInstallButtonClicked(object? sender, EventArgs e)
+    {
+        if (_busy)
+        {
+            return;
+        }
+
+        var candidate = Updates.LatestCandidate;
+
+        if (candidate is null)
+        {
+            return;
+        }
+
+        var answer = MessageBox.Show(this,
+            $"Загрузить и установить версию {candidate.Version}?\n\nПриложение перезапустится автоматически.",
+            "Установка обновления",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != DialogResult.Yes)
+        {
+            return;
+        }
+
+        SetBusy(true);
+
+        var progress = new Progress<int>(percent =>
+        {
+            _statusLabel.ForeColor = Color.Blue;
+            _statusLabel.Text = $"Загрузка обновления… {percent}%";
+        });
+
+        try
+        {
+            await Updates.PrepareAsync(candidate, progress, CancellationToken.None);
+
+            MessageBox.Show(this,
+                "Обновление загружено. Приложение закроется и установит новую версию.",
+                "Установка обновления",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+
+            Application.Exit();
+        }
+        catch (Exception exception)
+        {
+            _statusLabel.ForeColor = Color.Red;
+            _statusLabel.Text = $"Ошибка загрузки: {exception.Message}";
+
+            MessageBox.Show(this,
+                $"Не удалось установить обновление: {exception.Message}",
+                "Ошибка обновления",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+
+            SetBusy(false);
+        }
+    }
+
+    private static string FormatLastCheck(UpdateSettings? settings)
+    {
+        if (settings?.LastCheckUtc is { } lastCheck)
+        {
+            var local = lastCheck.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+            return $"Последняя проверка: {local}. Обновлений не найдено.";
+        }
+
+        return "Проверка обновлений ещё не выполнялась.";
+    }
+
+    private void RefreshRepositoryHint()
+    {
+        var text = _repositoryTextBox.Text.Trim();
+
+        if (text.Length == 0)
+        {
+            _repositoryHintLabel.ForeColor = Color.Gray;
+            _repositoryHintLabel.Text = $"Пусто — используется {Updates.DefaultRepositorySlug} (из сборки).";
+        }
+        else if (UpdateRepository.IsValidSlug(text))
+        {
+            _repositoryHintLabel.ForeColor = Color.Green;
+            _repositoryHintLabel.Text = $"✓ {text}";
+        }
+        else
+        {
+            _repositoryHintLabel.ForeColor = Color.Red;
+            _repositoryHintLabel.Text = "✗ Неверный формат. Ожидается owner/repo.";
+        }
+    }
+
+    private bool IsUpdatableNow()
+    {
+        return Updates.Kind switch
+        {
+            UpdateKind.Portable => true,
+            UpdateKind.FrameworkDependent => _allowFrameworkDependentCheckBox.Checked,
+            _ => false,
+        };
+    }
+
+    private void RefreshStatus(UpdateSettings? settings)
+    {
+        _currentVersionLabel.Text = $"Текущая версия: {Updates.CurrentVersion} (.NET {Environment.Version.Major})";
+
+        if (Updates.Kind == UpdateKind.Unsupported)
+        {
+            _statusLabel.ForeColor = Color.Gray;
+            _statusLabel.Text = "Автообновление недоступно для этой сборки (запуск из среды разработки).";
+            _checkNowButton.Enabled = false;
+            _installButton.Enabled = false;
+            return;
+        }
+
+        if (!IsUpdatableNow())
+        {
+            _statusLabel.ForeColor = Color.Gray;
+            _statusLabel.Text = "Автообновление выключено для сборки, требующей .NET. Включите опцию ниже.";
+            _checkNowButton.Enabled = false;
+            _installButton.Enabled = false;
+            return;
+        }
+
+        var candidate = Updates.LatestCandidate;
+
+        if (candidate is not null)
+        {
+            _statusLabel.ForeColor = Color.Green;
+            _statusLabel.Text = $"Доступно обновление: {candidate.Version}";
+            _installButton.Enabled = !_busy;
+        }
+        else
+        {
+            _statusLabel.ForeColor = Color.Gray;
+            _statusLabel.Text = FormatLastCheck(settings);
+            _installButton.Enabled = false;
+        }
+
+        _checkNowButton.Enabled = !_busy;
+    }
+
+    private void SetBusy(bool busy)
+    {
+        _busy = busy;
+        var updatable = !busy && IsUpdatableNow();
+        _checkNowButton.Enabled = updatable;
+        _installButton.Enabled = updatable && Updates.LatestCandidate is not null;
+    }
+}

--- a/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.resx
+++ b/PoproshaykaBot.WinForms/Forms/Settings/UpdateSettingsControl.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <!--
+      Microsoft ResX Schema
+
+      Version 2.0
+
+      The primary goals of this format is to allow a simple XML format
+      that is mostly human readable. The generation and parsing of the
+      various data types are done through the TypeConverter classes
+      associated with the data types.
+
+      Example:
+
+      ... ado.net/XML headers & schema ...
+      <resheader name="resmimetype">text/microsoft-resx</resheader>
+      <resheader name="version">2.0</resheader>
+      <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+      <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+      <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+      <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+      <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+          <value>[base64 mime encoded serialized .NET Framework object]</value>
+      </data>
+      <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+          <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+          <comment>This is a comment</comment>
+      </data>
+
+      There are any number of "resheader" rows that contain simple
+      name/value pairs.
+
+      Each data row contains a name, and value. The row also contains a
+      type or mimetype. Type corresponds to a .NET class that support
+      text/value conversion through the TypeConverter architecture.
+      Classes that don't support this are serialized and stored with the
+      mimetype set.
+
+      The mimetype is used for serialized objects, and tells the
+      ResXResourceReader how to depersist the object. This is currently not
+      extensible. For a given mimetype the value must be set accordingly:
+
+      Note - application/x-microsoft.net.object.binary.base64 is the format
+      that the ResXResourceWriter will generate, however the reader can
+      read any of the formats listed below.
+
+      mimetype: application/x-microsoft.net.object.binary.base64
+      value   : The object must be serialized with
+              : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+              : and then encoded with base64 encoding.
+
+      mimetype: application/x-microsoft.net.object.soap.base64
+      value   : The object must be serialized with
+              : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+              : and then encoded with base64 encoding.
+
+      mimetype: application/x-microsoft.net.object.bytearray.base64
+      value   : The object must be serialized into a byte array
+              : using a System.ComponentModel.TypeConverter
+              : and then encoded with base64 encoding.
+      -->
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata"
+                id="root"
+                xmlns="">
+        <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+        <xsd:element name="root" msdata:IsDataSet="true">
+            <xsd:complexType>
+                <xsd:choice maxOccurs="unbounded">
+                    <xsd:element name="metadata">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" use="required" type="xsd:string" />
+                            <xsd:attribute name="type" type="xsd:string" />
+                            <xsd:attribute name="mimetype" type="xsd:string" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="assembly">
+                        <xsd:complexType>
+                            <xsd:attribute name="alias" type="xsd:string" />
+                            <xsd:attribute name="name" type="xsd:string" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="data">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="resheader">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" />
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+            </xsd:complexType>
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+</root>

--- a/PoproshaykaBot.WinForms/Infrastructure/WebView2EnvironmentFactory.cs
+++ b/PoproshaykaBot.WinForms/Infrastructure/WebView2EnvironmentFactory.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Web.WebView2.Core;
+
+namespace PoproshaykaBot.WinForms.Infrastructure;
+
+public static class WebView2EnvironmentFactory
+{
+    private const int MaxAttempts = 10;
+    private const int RetryDelayMs = 600;
+
+    public static async Task<CoreWebView2Environment> CreateAsync(string userDataFolder, ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(userDataFolder);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        Directory.CreateDirectory(userDataFolder);
+
+        for (var attempt = 1; attempt < MaxAttempts; attempt++)
+        {
+            try
+            {
+                return await CoreWebView2Environment.CreateAsync(null, userDataFolder).ConfigureAwait(true);
+            }
+            catch (Exception exception) when (exception is not WebView2RuntimeNotFoundException)
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug(exception,
+                        "Папка данных WebView2 {Folder} недоступна (попытка {Attempt}/{Max}), повтор через {Delay} мс — вероятно, занята завершающимся процессом после обновления",
+                        userDataFolder, attempt, MaxAttempts, RetryDelayMs);
+                }
+
+                await Task.Delay(RetryDelayMs).ConfigureAwait(true);
+            }
+        }
+
+        return await CoreWebView2Environment.CreateAsync(null, userDataFolder).ConfigureAwait(true);
+    }
+}

--- a/PoproshaykaBot.WinForms/MainForm.Designer.cs
+++ b/PoproshaykaBot.WinForms/MainForm.Designer.cs
@@ -34,6 +34,11 @@ partial class MainForm
     {
         var resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
         _mainTableLayoutPanel = new TableLayoutPanel();
+        _updateBannerPanel = new Panel();
+        _updateBannerLabel = new Label();
+        _updateBannerButtonsPanel = new FlowLayoutPanel();
+        _updateBannerUpdateButton = new Button();
+        _updateBannerSkipButton = new Button();
         _onboardingBannerPanel = new Panel();
         _onboardingBannerLabel = new Label();
         _onboardingBannerButton = new Button();
@@ -48,6 +53,8 @@ partial class MainForm
         _streamMonitoringStatusLabel = new ToolStripStatusLabel();
         _statusStrip = new StatusStrip();
         _mainTableLayoutPanel.SuspendLayout();
+        _updateBannerPanel.SuspendLayout();
+        _updateBannerButtonsPanel.SuspendLayout();
         _onboardingBannerPanel.SuspendLayout();
         _mainToolStrip.SuspendLayout();
         _statusStrip.SuspendLayout();
@@ -57,18 +64,78 @@ partial class MainForm
         // 
         _mainTableLayoutPanel.ColumnCount = 1;
         _mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-        _mainTableLayoutPanel.Controls.Add(_onboardingBannerPanel, 0, 0);
-        _mainTableLayoutPanel.Controls.Add(_mainToolStrip, 0, 1);
-        _mainTableLayoutPanel.Controls.Add(_dashboardControl, 0, 2);
+        _mainTableLayoutPanel.Controls.Add(_updateBannerPanel, 0, 0);
+        _mainTableLayoutPanel.Controls.Add(_onboardingBannerPanel, 0, 1);
+        _mainTableLayoutPanel.Controls.Add(_mainToolStrip, 0, 2);
+        _mainTableLayoutPanel.Controls.Add(_dashboardControl, 0, 3);
         _mainTableLayoutPanel.Dock = DockStyle.Fill;
         _mainTableLayoutPanel.Location = new Point(0, 0);
         _mainTableLayoutPanel.Name = "_mainTableLayoutPanel";
-        _mainTableLayoutPanel.RowCount = 3;
+        _mainTableLayoutPanel.RowCount = 4;
+        _mainTableLayoutPanel.RowStyles.Add(new RowStyle());
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle());
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
         _mainTableLayoutPanel.Size = new Size(800, 562);
         _mainTableLayoutPanel.TabIndex = 0;
+        //
+        // _updateBannerPanel
+        //
+        _updateBannerPanel.BackColor = Color.LightYellow;
+        _updateBannerPanel.Controls.Add(_updateBannerLabel);
+        _updateBannerPanel.Controls.Add(_updateBannerButtonsPanel);
+        _updateBannerPanel.Dock = DockStyle.Fill;
+        _updateBannerPanel.Margin = new Padding(0);
+        _updateBannerPanel.MinimumSize = new Size(0, 40);
+        _updateBannerPanel.Name = "_updateBannerPanel";
+        _updateBannerPanel.Padding = new Padding(10, 6, 10, 6);
+        _updateBannerPanel.Size = new Size(800, 40);
+        _updateBannerPanel.TabIndex = 0;
+        _updateBannerPanel.Visible = false;
+        //
+        // _updateBannerLabel
+        //
+        _updateBannerLabel.AutoSize = false;
+        _updateBannerLabel.Dock = DockStyle.Fill;
+        _updateBannerLabel.ForeColor = Color.DarkGoldenrod;
+        _updateBannerLabel.Name = "_updateBannerLabel";
+        _updateBannerLabel.Size = new Size(620, 28);
+        _updateBannerLabel.TabIndex = 0;
+        _updateBannerLabel.Text = "🔄 Доступна новая версия.";
+        _updateBannerLabel.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // _updateBannerButtonsPanel
+        //
+        _updateBannerButtonsPanel.AutoSize = true;
+        _updateBannerButtonsPanel.Controls.Add(_updateBannerUpdateButton);
+        _updateBannerButtonsPanel.Controls.Add(_updateBannerSkipButton);
+        _updateBannerButtonsPanel.Dock = DockStyle.Right;
+        _updateBannerButtonsPanel.FlowDirection = FlowDirection.RightToLeft;
+        _updateBannerButtonsPanel.Margin = new Padding(0);
+        _updateBannerButtonsPanel.Name = "_updateBannerButtonsPanel";
+        _updateBannerButtonsPanel.Size = new Size(210, 28);
+        _updateBannerButtonsPanel.TabIndex = 1;
+        _updateBannerButtonsPanel.WrapContents = false;
+        //
+        // _updateBannerUpdateButton
+        //
+        _updateBannerUpdateButton.AutoSize = true;
+        _updateBannerUpdateButton.Name = "_updateBannerUpdateButton";
+        _updateBannerUpdateButton.Size = new Size(110, 28);
+        _updateBannerUpdateButton.TabIndex = 0;
+        _updateBannerUpdateButton.Text = "⬇️ Обновить";
+        _updateBannerUpdateButton.UseVisualStyleBackColor = true;
+        _updateBannerUpdateButton.Click += OnUpdateBannerUpdateButtonClicked;
+        //
+        // _updateBannerSkipButton
+        //
+        _updateBannerSkipButton.AutoSize = true;
+        _updateBannerSkipButton.Name = "_updateBannerSkipButton";
+        _updateBannerSkipButton.Size = new Size(95, 28);
+        _updateBannerSkipButton.TabIndex = 1;
+        _updateBannerSkipButton.Text = "Пропустить";
+        _updateBannerSkipButton.UseVisualStyleBackColor = true;
+        _updateBannerSkipButton.Click += OnUpdateBannerSkipButtonClicked;
         //
         // _onboardingBannerPanel
         //
@@ -211,6 +278,9 @@ partial class MainForm
         Text = "Попрощайка Бот - Управление";
         _mainTableLayoutPanel.ResumeLayout(false);
         _mainTableLayoutPanel.PerformLayout();
+        _updateBannerPanel.ResumeLayout(false);
+        _updateBannerButtonsPanel.ResumeLayout(false);
+        _updateBannerButtonsPanel.PerformLayout();
         _onboardingBannerPanel.ResumeLayout(false);
         _onboardingBannerPanel.PerformLayout();
         _mainToolStrip.ResumeLayout(false);
@@ -222,6 +292,11 @@ partial class MainForm
     }
 
     private TableLayoutPanel _mainTableLayoutPanel;
+    private Panel _updateBannerPanel;
+    private Label _updateBannerLabel;
+    private FlowLayoutPanel _updateBannerButtonsPanel;
+    private Button _updateBannerUpdateButton;
+    private Button _updateBannerSkipButton;
     private Panel _onboardingBannerPanel;
     private Label _onboardingBannerLabel;
     private Button _onboardingBannerButton;

--- a/PoproshaykaBot.WinForms/MainForm.cs
+++ b/PoproshaykaBot.WinForms/MainForm.cs
@@ -3,6 +3,7 @@ using PoproshaykaBot.Core.Chat;
 using PoproshaykaBot.Core.Infrastructure.Events;
 using PoproshaykaBot.Core.Infrastructure.Events.Lifecycle;
 using PoproshaykaBot.Core.Infrastructure.Events.Streaming;
+using PoproshaykaBot.Core.Infrastructure.Events.Update;
 using PoproshaykaBot.Core.Infrastructure.Hosting;
 using PoproshaykaBot.Core.Settings;
 using PoproshaykaBot.Core.Settings.Onboarding;
@@ -10,6 +11,7 @@ using PoproshaykaBot.Core.Settings.Stores;
 using PoproshaykaBot.Core.Settings.Ui;
 using PoproshaykaBot.Core.Streaming;
 using PoproshaykaBot.Core.Twitch.Auth;
+using PoproshaykaBot.Core.Update;
 using PoproshaykaBot.WinForms.Forms.Onboarding;
 using PoproshaykaBot.WinForms.Forms.Settings;
 using PoproshaykaBot.WinForms.Forms.StreamHistory;
@@ -27,6 +29,7 @@ public partial class MainForm : Form
     private readonly DashboardLayoutStore _dashboardLayoutStore;
     private readonly BotConnectionManager _connectionManager;
     private readonly OnboardingChecklist _onboardingChecklist;
+    private readonly IUpdateCoordinator _updateCoordinator;
     private readonly ILogger<MainForm> _logger;
     private readonly List<IDisposable> _subs = [];
 
@@ -51,6 +54,7 @@ public partial class MainForm : Form
         SettingsManager settingsManager,
         DashboardLayoutStore dashboardLayoutStore,
         OnboardingChecklist onboardingChecklist,
+        IUpdateCoordinator updateCoordinator,
         ILogger<MainForm> logger)
     {
         _forms = forms;
@@ -60,6 +64,7 @@ public partial class MainForm : Form
         _settingsManager = settingsManager;
         _dashboardLayoutStore = dashboardLayoutStore;
         _onboardingChecklist = onboardingChecklist;
+        _updateCoordinator = updateCoordinator;
         _logger = logger;
 
         InitializeComponent();
@@ -85,11 +90,13 @@ public partial class MainForm : Form
         _subs.Add(_eventBus.SubscribeOnUi<BotConnectionStatusUpdated>(this, statusEvent => OnBotConnectionProgress(statusEvent.Message)));
         _subs.Add(_eventBus.SubscribeOnUi<BotLifecyclePhaseChanged>(this, OnBotLifecyclePhaseChanged));
         _subs.Add(_eventBus.SubscribeOnUi<StreamMonitoringStatusChanged>(this, OnStreamMonitoringStatusChanged));
+        _subs.Add(_eventBus.SubscribeOnUi<UpdateAvailable>(this, _ => RefreshUpdateBanner()));
         _subs.DisposeOnClose(this);
 
         LoadSettings();
         OpenOnboardingWizardIfNeeded();
         RefreshOnboardingBanner();
+        RefreshUpdateBanner();
         _logger.LogInformation("Приложение запущено. Нажмите 'Подключить бота' для начала работы.");
 
         KeyPreview = true;
@@ -212,6 +219,68 @@ public partial class MainForm : Form
         OnOpenStreamHistory();
     }
 
+    private async void OnUpdateBannerUpdateButtonClicked(object? sender, EventArgs e)
+    {
+        var candidate = _updateCoordinator.LatestCandidate;
+
+        if (candidate is null)
+        {
+            return;
+        }
+
+        var answer = MessageBox.Show(this,
+            $"Загрузить и установить версию {candidate.Version}?\n\nПриложение перезапустится автоматически.",
+            "Установка обновления",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != DialogResult.Yes)
+        {
+            return;
+        }
+
+        _updateBannerUpdateButton.Enabled = false;
+        _updateBannerSkipButton.Enabled = false;
+
+        var progress = new Progress<int>(percent =>
+            _updateBannerLabel.Text = $"Загрузка обновления {candidate.Version}… {percent}%");
+
+        try
+        {
+            await _updateCoordinator.PrepareAsync(candidate, progress, CancellationToken.None);
+            _logger.LogInformation("Обновление {Version} загружено, приложение перезапустится", candidate.Version);
+            Application.Exit();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Ошибка загрузки обновления");
+
+            MessageBox.Show(this,
+                $"Не удалось установить обновление: {exception.Message}",
+                "Ошибка обновления",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+
+            _updateBannerUpdateButton.Enabled = true;
+            _updateBannerSkipButton.Enabled = true;
+            RefreshUpdateBanner();
+        }
+    }
+
+    private void OnUpdateBannerSkipButtonClicked(object? sender, EventArgs e)
+    {
+        var candidate = _updateCoordinator.LatestCandidate;
+
+        if (candidate is null)
+        {
+            return;
+        }
+
+        _updateCoordinator.SkipVersion(candidate.Version.ToString());
+        _updateBannerPanel.Visible = false;
+        _logger.LogInformation("Версия {Version} пропущена", candidate.Version);
+    }
+
     private static string GetDisplayVersion()
     {
         var version = Application.ProductVersion;
@@ -290,6 +359,20 @@ public partial class MainForm : Form
 
         _onboardingBannerLabel.Text = $"⚠ Бот не готов к работе. Не настроено: {string.Join(", ", missing)}.";
         _onboardingBannerPanel.Visible = true;
+    }
+
+    private void RefreshUpdateBanner()
+    {
+        var candidate = _updateCoordinator.LatestCandidate;
+
+        if (candidate is null || !_updateCoordinator.IsUpdatable)
+        {
+            _updateBannerPanel.Visible = false;
+            return;
+        }
+
+        _updateBannerLabel.Text = $"🔄 Доступна новая версия {candidate.Version} (установлена {_updateCoordinator.CurrentVersion}).";
+        _updateBannerPanel.Visible = true;
     }
 
     private async Task ShutdownAndCloseAsync()

--- a/PoproshaykaBot.WinForms/PoproshaykaBot.WinForms.csproj
+++ b/PoproshaykaBot.WinForms/PoproshaykaBot.WinForms.csproj
@@ -19,8 +19,20 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GitHubRepository>MaxNagibator/PoproshaykaBot</GitHubRepository>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="GitHubRepository" Value="$(GitHubRepository)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(PortableMode)' == 'true'">
     <AssemblyMetadata Include="PortableMode" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UpdatableBuild)' == 'true'">
+    <AssemblyMetadata Include="UpdatableBuild" Value="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PoproshaykaBot.WinForms/Program.cs
+++ b/PoproshaykaBot.WinForms/Program.cs
@@ -21,6 +21,8 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Extensions.Logging;
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using Timer = System.Windows.Forms.Timer;
 
 namespace PoproshaykaBot.WinForms;
@@ -47,9 +49,30 @@ public static class Program
             .WriteTo.Sink(uiLogSink, LogEventLevel.Information)
             .CreateLogger();
 
+        Mutex? singleInstanceMutex = null;
+
         try
         {
             Log.Information("Запуск приложения...");
+
+            singleInstanceMutex = AcquireSingleInstanceLock(isFinalizeUpdate);
+
+            if (singleInstanceMutex is null)
+            {
+                Log.Information("Обнаружен уже запущенный экземпляр приложения. Завершение работы");
+
+                if (!isUiSmoke)
+                {
+                    MessageBox.Show(
+                        "PoproshaykaBot уже запущен.\n\nОдновременно может работать только один экземпляр приложения.",
+                        "Приложение уже запущено",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                }
+
+                return;
+            }
+
             Log.Information("Режим хранения данных: {Mode}, базовая директория: {BaseDirectory}",
                 ResolveStorageMode(),
                 AppPaths.BaseDirectory);
@@ -79,6 +102,7 @@ public static class Program
         {
             Log.Information("Завершение работы приложения");
             Log.CloseAndFlush();
+            singleInstanceMutex?.Dispose();
         }
     }
 
@@ -265,6 +289,26 @@ public static class Program
         }
 
         return AppPaths.IsPortable ? "portable" : "AppData";
+    }
+
+    private static Mutex? AcquireSingleInstanceLock(bool isFinalizeUpdate)
+    {
+        var mutex = new Mutex(true, BuildSingleInstanceMutexName(), out var createdNew);
+
+        if (createdNew || isFinalizeUpdate)
+        {
+            return mutex;
+        }
+
+        mutex.Dispose();
+        return null;
+    }
+
+    private static string BuildSingleInstanceMutexName()
+    {
+        var key = AppPaths.BaseDirectory.ToLowerInvariant();
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
+        return $"Local\\PoproshaykaBot-{hash[..16]}";
     }
 
     private static Timer CreateMemoryWatchdogTimer()

--- a/PoproshaykaBot.WinForms/Program.cs
+++ b/PoproshaykaBot.WinForms/Program.cs
@@ -14,6 +14,7 @@ using PoproshaykaBot.Core.Settings.Migrations;
 using PoproshaykaBot.Core.Statistics;
 using PoproshaykaBot.Core.Streaming;
 using PoproshaykaBot.Core.Twitch;
+using PoproshaykaBot.Core.Update;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 using Serilog;
 using Serilog.Debugging;
@@ -30,6 +31,7 @@ public static class Program
     private static void Main(string[] args)
     {
         var isUiSmoke = args.Any(arg => string.Equals(arg, "--ui-smoke", StringComparison.OrdinalIgnoreCase));
+        var isFinalizeUpdate = args.Any(arg => string.Equals(arg, UpdateApplier.FinalizeArgument, StringComparison.OrdinalIgnoreCase));
 
         const string OutputTemplate = "[{Timestamp:HH:mm:ss.fff} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}";
 
@@ -52,10 +54,15 @@ public static class Program
                 ResolveStorageMode(),
                 AppPaths.BaseDirectory);
 
+            if (isFinalizeUpdate)
+            {
+                FinalizeUpdate();
+            }
+
             Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
             ApplicationConfiguration.Initialize();
 
-            var memoryCheckTimer = CreateMemoryWatchdogTimer();
+            using var memoryCheckTimer = CreateMemoryWatchdogTimer();
 
             if (!isUiSmoke)
             {
@@ -115,6 +122,55 @@ public static class Program
             }
 
             serviceProvider.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+            if (!isUiSmoke)
+            {
+                ApplyPendingUpdate();
+            }
+        }
+    }
+
+    private static void FinalizeUpdate()
+    {
+        using var loggerFactory = new SerilogLoggerFactory(Log.Logger);
+        var logger = loggerFactory.CreateLogger(nameof(UpdateFinalizer));
+
+        try
+        {
+            var executablePath = Environment.ProcessPath;
+
+            if (string.IsNullOrEmpty(executablePath))
+            {
+                return;
+            }
+
+            UpdateFinalizer.Run(UpdatePaths.StagingDirectory(executablePath), executablePath, logger);
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Ошибка очистки после обновления");
+        }
+    }
+
+    private static void ApplyPendingUpdate()
+    {
+        var executablePath = Environment.ProcessPath;
+
+        if (string.IsNullOrEmpty(executablePath))
+        {
+            return;
+        }
+
+        using var loggerFactory = new SerilogLoggerFactory(Log.Logger);
+        var logger = loggerFactory.CreateLogger(nameof(UpdateApplier));
+
+        try
+        {
+            UpdateApplier.TryApplyPending(UpdatePaths.StagingDirectory(executablePath), executablePath, logger);
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Ошибка применения запланированного обновления");
         }
     }
 
@@ -273,6 +329,7 @@ public static class Program
             .AddPolls()
             .AddHttpServer()
             .AddObsIntegration()
+            .AddSelfUpdate()
             .AddDashboardTiles()
             .AddForms();
     }

--- a/PoproshaykaBot.WinForms/Tiles/ChatOverlayPreviewTileControl.cs
+++ b/PoproshaykaBot.WinForms/Tiles/ChatOverlayPreviewTileControl.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using PoproshaykaBot.Core.Settings;
+using PoproshaykaBot.Core.Twitch.Auth;
+using PoproshaykaBot.WinForms.Infrastructure;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 
 namespace PoproshaykaBot.WinForms.Tiles;
@@ -66,7 +68,9 @@ public sealed partial class ChatOverlayPreviewTileControl : UserControl, IDashbo
     {
         try
         {
-            await _webView.EnsureCoreWebView2Async(null);
+            var userDataFolder = WebView2UserDataFolders.ResolveOverlayPreview();
+            var environment = await WebView2EnvironmentFactory.CreateAsync(userDataFolder, Logger);
+            await _webView.EnsureCoreWebView2Async(environment);
             UpdateOverlayUrl();
         }
         catch (Exception ex)

--- a/PoproshaykaBot.WinForms/Tiles/ObsInfoTileType.cs
+++ b/PoproshaykaBot.WinForms/Tiles/ObsInfoTileType.cs
@@ -3,7 +3,7 @@ using PoproshaykaBot.WinForms.Widgets;
 
 namespace PoproshaykaBot.WinForms.Tiles;
 
-public sealed class ObsInfoTileType() : DashboardTileType(TypeId, "🎬 OBS", 200, 380)
+public sealed class ObsInfoTileType() : DashboardTileType(TypeId, "🎬 OBS", 320, 380)
 {
     public const string TypeId = "obs-info";
 

--- a/PoproshaykaBot.WinForms/Widgets/ChatDisplay.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ChatDisplay.cs
@@ -3,6 +3,7 @@ using Microsoft.Web.WebView2.Core;
 using PoproshaykaBot.Core.Infrastructure;
 using PoproshaykaBot.Core.Settings;
 using PoproshaykaBot.Core.Twitch.Auth;
+using PoproshaykaBot.WinForms.Infrastructure;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 using PoproshaykaBot.WinForms.Tiles;
 using System.Diagnostics;
@@ -305,9 +306,7 @@ public sealed partial class ChatDisplay : UserControl, IDashboardTileHeaderProvi
         {
             var userDataFolder = WebView2UserDataFolders.Resolve(Settings.Current.Twitch.ChatDisplayAccount);
 
-            Directory.CreateDirectory(userDataFolder);
-
-            var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
+            var env = await WebView2EnvironmentFactory.CreateAsync(userDataFolder, Logger);
             await _webView.EnsureCoreWebView2Async(env);
 
             if (IsDisposed || Disposing)

--- a/PoproshaykaBot.WinForms/Widgets/ObsCardChipTone.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsCardChipTone.cs
@@ -1,0 +1,9 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+public enum ObsCardChipTone
+{
+    Neutral = 0,
+    Ok = 1,
+    Warn = 2,
+    Bad = 3,
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
@@ -21,8 +21,8 @@ sealed partial class ObsInfoWidget
         _mainTableLayoutPanel = new TableLayoutPanel();
         _sceneLabel = new Label();
         _outputsTableLayoutPanel = new TableLayoutPanel();
-        _streamingLabel = new Label();
-        _recordingLabel = new Label();
+        _streamStatusCard = new ObsOutputStatusCard();
+        _recordStatusCard = new ObsOutputStatusCard();
         _sourcesScrollPanel = new Panel();
         _sourcesLayoutPanel = new TableLayoutPanel();
         _refreshTimer = new System.Windows.Forms.Timer(components);
@@ -45,9 +45,9 @@ sealed partial class ObsInfoWidget
         _mainTableLayoutPanel.Padding = new Padding(3);
         _mainTableLayoutPanel.RowCount = 3;
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 26F));
-        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
+        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 80F));
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _mainTableLayoutPanel.Size = new Size(320, 160);
+        _mainTableLayoutPanel.Size = new Size(320, 210);
         _mainTableLayoutPanel.TabIndex = 0;
         //
         // _sceneLabel
@@ -66,43 +66,41 @@ sealed partial class ObsInfoWidget
         _outputsTableLayoutPanel.ColumnCount = 2;
         _outputsTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
         _outputsTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-        _outputsTableLayoutPanel.Controls.Add(_streamingLabel, 0, 0);
-        _outputsTableLayoutPanel.Controls.Add(_recordingLabel, 1, 0);
+        _outputsTableLayoutPanel.Controls.Add(_streamStatusCard, 0, 0);
+        _outputsTableLayoutPanel.Controls.Add(_recordStatusCard, 1, 0);
         _outputsTableLayoutPanel.Dock = DockStyle.Fill;
         _outputsTableLayoutPanel.Location = new Point(3, 29);
         _outputsTableLayoutPanel.Margin = new Padding(0);
         _outputsTableLayoutPanel.Name = "_outputsTableLayoutPanel";
         _outputsTableLayoutPanel.RowCount = 1;
         _outputsTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _outputsTableLayoutPanel.Size = new Size(314, 30);
+        _outputsTableLayoutPanel.Size = new Size(314, 80);
         _outputsTableLayoutPanel.TabIndex = 1;
         //
-        // _streamingLabel
+        // _streamStatusCard
         //
-        _streamingLabel.AutoEllipsis = true;
-        _streamingLabel.Dock = DockStyle.Fill;
-        _streamingLabel.ForeColor = Color.DimGray;
-        _streamingLabel.Name = "_streamingLabel";
-        _streamingLabel.TabIndex = 0;
-        _streamingLabel.Text = "Эфир: —";
-        _streamingLabel.TextAlign = ContentAlignment.MiddleLeft;
+        _streamStatusCard.Dock = DockStyle.Fill;
+        _streamStatusCard.Location = new Point(0, 0);
+        _streamStatusCard.Margin = new Padding(0, 0, 3, 0);
+        _streamStatusCard.Name = "_streamStatusCard";
+        _streamStatusCard.Size = new Size(154, 80);
+        _streamStatusCard.TabIndex = 0;
         //
-        // _recordingLabel
+        // _recordStatusCard
         //
-        _recordingLabel.AutoEllipsis = true;
-        _recordingLabel.Dock = DockStyle.Fill;
-        _recordingLabel.ForeColor = Color.DimGray;
-        _recordingLabel.Name = "_recordingLabel";
-        _recordingLabel.TabIndex = 1;
-        _recordingLabel.Text = "Запись: —";
-        _recordingLabel.TextAlign = ContentAlignment.MiddleLeft;
+        _recordStatusCard.Dock = DockStyle.Fill;
+        _recordStatusCard.Location = new Point(160, 0);
+        _recordStatusCard.Margin = new Padding(3, 0, 0, 0);
+        _recordStatusCard.Name = "_recordStatusCard";
+        _recordStatusCard.Size = new Size(154, 80);
+        _recordStatusCard.TabIndex = 1;
         //
         // _sourcesScrollPanel
         //
         _sourcesScrollPanel.AutoScroll = true;
         _sourcesScrollPanel.Controls.Add(_sourcesLayoutPanel);
         _sourcesScrollPanel.Dock = DockStyle.Fill;
-        _sourcesScrollPanel.Location = new Point(6, 62);
+        _sourcesScrollPanel.Location = new Point(6, 112);
         _sourcesScrollPanel.Margin = new Padding(3, 3, 3, 3);
         _sourcesScrollPanel.Name = "_sourcesScrollPanel";
         _sourcesScrollPanel.Size = new Size(308, 92);
@@ -138,7 +136,7 @@ sealed partial class ObsInfoWidget
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_mainTableLayoutPanel);
         Name = "ObsInfoWidget";
-        Size = new Size(320, 160);
+        Size = new Size(320, 210);
         _mainTableLayoutPanel.ResumeLayout(false);
         _outputsTableLayoutPanel.ResumeLayout(false);
         _sourcesScrollPanel.ResumeLayout(false);
@@ -149,8 +147,8 @@ sealed partial class ObsInfoWidget
     private TableLayoutPanel _mainTableLayoutPanel;
     private TableLayoutPanel _outputsTableLayoutPanel;
     private Label _sceneLabel;
-    private Label _streamingLabel;
-    private Label _recordingLabel;
+    private ObsOutputStatusCard _streamStatusCard;
+    private ObsOutputStatusCard _recordStatusCard;
     private Panel _sourcesScrollPanel;
     private TableLayoutPanel _sourcesLayoutPanel;
     private System.Windows.Forms.Timer _refreshTimer;

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
@@ -45,9 +45,9 @@ sealed partial class ObsInfoWidget
         _mainTableLayoutPanel.Padding = new Padding(3);
         _mainTableLayoutPanel.RowCount = 3;
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 26F));
-        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 80F));
+        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 160F));
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _mainTableLayoutPanel.Size = new Size(320, 210);
+        _mainTableLayoutPanel.Size = new Size(320, 290);
         _mainTableLayoutPanel.TabIndex = 0;
         //
         // _sceneLabel
@@ -74,7 +74,7 @@ sealed partial class ObsInfoWidget
         _outputsTableLayoutPanel.Name = "_outputsTableLayoutPanel";
         _outputsTableLayoutPanel.RowCount = 1;
         _outputsTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _outputsTableLayoutPanel.Size = new Size(314, 80);
+        _outputsTableLayoutPanel.Size = new Size(314, 160);
         _outputsTableLayoutPanel.TabIndex = 1;
         //
         // _streamStatusCard
@@ -83,7 +83,7 @@ sealed partial class ObsInfoWidget
         _streamStatusCard.Location = new Point(0, 0);
         _streamStatusCard.Margin = new Padding(0, 0, 3, 0);
         _streamStatusCard.Name = "_streamStatusCard";
-        _streamStatusCard.Size = new Size(154, 80);
+        _streamStatusCard.Size = new Size(154, 160);
         _streamStatusCard.TabIndex = 0;
         //
         // _recordStatusCard
@@ -92,7 +92,7 @@ sealed partial class ObsInfoWidget
         _recordStatusCard.Location = new Point(160, 0);
         _recordStatusCard.Margin = new Padding(3, 0, 0, 0);
         _recordStatusCard.Name = "_recordStatusCard";
-        _recordStatusCard.Size = new Size(154, 80);
+        _recordStatusCard.Size = new Size(154, 160);
         _recordStatusCard.TabIndex = 1;
         //
         // _sourcesScrollPanel
@@ -100,7 +100,7 @@ sealed partial class ObsInfoWidget
         _sourcesScrollPanel.AutoScroll = true;
         _sourcesScrollPanel.Controls.Add(_sourcesLayoutPanel);
         _sourcesScrollPanel.Dock = DockStyle.Fill;
-        _sourcesScrollPanel.Location = new Point(6, 112);
+        _sourcesScrollPanel.Location = new Point(6, 192);
         _sourcesScrollPanel.Margin = new Padding(3, 3, 3, 3);
         _sourcesScrollPanel.Name = "_sourcesScrollPanel";
         _sourcesScrollPanel.Size = new Size(308, 92);
@@ -136,7 +136,7 @@ sealed partial class ObsInfoWidget
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_mainTableLayoutPanel);
         Name = "ObsInfoWidget";
-        Size = new Size(320, 210);
+        Size = new Size(320, 290);
         _mainTableLayoutPanel.ResumeLayout(false);
         _outputsTableLayoutPanel.ResumeLayout(false);
         _sourcesScrollPanel.ResumeLayout(false);

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.Designer.cs
@@ -23,15 +23,13 @@ sealed partial class ObsInfoWidget
         _outputsTableLayoutPanel = new TableLayoutPanel();
         _streamingLabel = new Label();
         _recordingLabel = new Label();
-        _microphoneStateLabel = new Label();
-        _volumeMeterPanel = new Panel();
-        _volumeMeterFillPanel = new Panel();
-        _microphoneLabel = new Label();
+        _sourcesScrollPanel = new Panel();
+        _sourcesLayoutPanel = new TableLayoutPanel();
         _refreshTimer = new System.Windows.Forms.Timer(components);
         _volumeMeterTimer = new System.Windows.Forms.Timer(components);
         _mainTableLayoutPanel.SuspendLayout();
         _outputsTableLayoutPanel.SuspendLayout();
-        _volumeMeterPanel.SuspendLayout();
+        _sourcesScrollPanel.SuspendLayout();
         SuspendLayout();
         //
         // _mainTableLayoutPanel
@@ -40,19 +38,14 @@ sealed partial class ObsInfoWidget
         _mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
         _mainTableLayoutPanel.Controls.Add(_sceneLabel, 0, 0);
         _mainTableLayoutPanel.Controls.Add(_outputsTableLayoutPanel, 0, 1);
-        _mainTableLayoutPanel.Controls.Add(_microphoneStateLabel, 0, 2);
-        _mainTableLayoutPanel.Controls.Add(_volumeMeterPanel, 0, 3);
-        _mainTableLayoutPanel.Controls.Add(_microphoneLabel, 0, 4);
+        _mainTableLayoutPanel.Controls.Add(_sourcesScrollPanel, 0, 2);
         _mainTableLayoutPanel.Dock = DockStyle.Fill;
         _mainTableLayoutPanel.Location = new Point(0, 0);
         _mainTableLayoutPanel.Name = "_mainTableLayoutPanel";
         _mainTableLayoutPanel.Padding = new Padding(3);
-        _mainTableLayoutPanel.RowCount = 6;
+        _mainTableLayoutPanel.RowCount = 3;
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 26F));
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
-        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 42F));
-        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 22F));
-        _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 34F));
         _mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
         _mainTableLayoutPanel.Size = new Size(320, 160);
         _mainTableLayoutPanel.TabIndex = 0;
@@ -104,54 +97,30 @@ sealed partial class ObsInfoWidget
         _recordingLabel.Text = "Запись: —";
         _recordingLabel.TextAlign = ContentAlignment.MiddleLeft;
         //
-        // _microphoneStateLabel
+        // _sourcesScrollPanel
         //
-        _microphoneStateLabel.AutoEllipsis = true;
-        _microphoneStateLabel.BackColor = Color.Gray;
-        _microphoneStateLabel.Dock = DockStyle.Fill;
-        _microphoneStateLabel.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-        _microphoneStateLabel.ForeColor = Color.White;
-        _microphoneStateLabel.Location = new Point(6, 62);
-        _microphoneStateLabel.Margin = new Padding(3, 3, 3, 3);
-        _microphoneStateLabel.Name = "_microphoneStateLabel";
-        _microphoneStateLabel.Size = new Size(308, 36);
-        _microphoneStateLabel.TabIndex = 2;
-        _microphoneStateLabel.Text = "МИКРОФОН —";
-        _microphoneStateLabel.TextAlign = ContentAlignment.MiddleCenter;
+        _sourcesScrollPanel.AutoScroll = true;
+        _sourcesScrollPanel.Controls.Add(_sourcesLayoutPanel);
+        _sourcesScrollPanel.Dock = DockStyle.Fill;
+        _sourcesScrollPanel.Location = new Point(6, 62);
+        _sourcesScrollPanel.Margin = new Padding(3, 3, 3, 3);
+        _sourcesScrollPanel.Name = "_sourcesScrollPanel";
+        _sourcesScrollPanel.Size = new Size(308, 92);
+        _sourcesScrollPanel.TabIndex = 2;
         //
-        // _volumeMeterPanel
+        // _sourcesLayoutPanel
         //
-        _volumeMeterPanel.BackColor = Color.Gainsboro;
-        _volumeMeterPanel.BorderStyle = BorderStyle.FixedSingle;
-        _volumeMeterPanel.Controls.Add(_volumeMeterFillPanel);
-        _volumeMeterPanel.Dock = DockStyle.Fill;
-        _volumeMeterPanel.Location = new Point(6, 104);
-        _volumeMeterPanel.Margin = new Padding(3, 3, 3, 3);
-        _volumeMeterPanel.Name = "_volumeMeterPanel";
-        _volumeMeterPanel.Size = new Size(308, 16);
-        _volumeMeterPanel.TabIndex = 3;
-        _volumeMeterPanel.Resize += OnVolumeMeterPanelResize;
-        //
-        // _volumeMeterFillPanel
-        //
-        _volumeMeterFillPanel.BackColor = Color.SeaGreen;
-        _volumeMeterFillPanel.Dock = DockStyle.Left;
-        _volumeMeterFillPanel.Location = new Point(0, 0);
-        _volumeMeterFillPanel.Name = "_volumeMeterFillPanel";
-        _volumeMeterFillPanel.Size = new Size(0, 14);
-        _volumeMeterFillPanel.TabIndex = 0;
-        //
-        // _microphoneLabel
-        //
-        _microphoneLabel.AutoEllipsis = true;
-        _microphoneLabel.Dock = DockStyle.Fill;
-        _microphoneLabel.ForeColor = Color.DimGray;
-        _microphoneLabel.Location = new Point(6, 123);
-        _microphoneLabel.Name = "_microphoneLabel";
-        _microphoneLabel.Size = new Size(308, 34);
-        _microphoneLabel.TabIndex = 4;
-        _microphoneLabel.Text = "Микрофон: —";
-        _microphoneLabel.TextAlign = ContentAlignment.MiddleLeft;
+        _sourcesLayoutPanel.AutoSize = true;
+        _sourcesLayoutPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        _sourcesLayoutPanel.ColumnCount = 1;
+        _sourcesLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _sourcesLayoutPanel.Dock = DockStyle.Top;
+        _sourcesLayoutPanel.Location = new Point(0, 0);
+        _sourcesLayoutPanel.Margin = new Padding(0);
+        _sourcesLayoutPanel.Name = "_sourcesLayoutPanel";
+        _sourcesLayoutPanel.RowCount = 0;
+        _sourcesLayoutPanel.Size = new Size(308, 0);
+        _sourcesLayoutPanel.TabIndex = 0;
         //
         // _refreshTimer
         //
@@ -172,7 +141,8 @@ sealed partial class ObsInfoWidget
         Size = new Size(320, 160);
         _mainTableLayoutPanel.ResumeLayout(false);
         _outputsTableLayoutPanel.ResumeLayout(false);
-        _volumeMeterPanel.ResumeLayout(false);
+        _sourcesScrollPanel.ResumeLayout(false);
+        _sourcesScrollPanel.PerformLayout();
         ResumeLayout(false);
     }
 
@@ -181,10 +151,8 @@ sealed partial class ObsInfoWidget
     private Label _sceneLabel;
     private Label _streamingLabel;
     private Label _recordingLabel;
-    private Label _microphoneStateLabel;
-    private Panel _volumeMeterPanel;
-    private Panel _volumeMeterFillPanel;
-    private Label _microphoneLabel;
+    private Panel _sourcesScrollPanel;
+    private TableLayoutPanel _sourcesLayoutPanel;
     private System.Windows.Forms.Timer _refreshTimer;
     private System.Windows.Forms.Timer _volumeMeterTimer;
 }

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
@@ -20,17 +20,16 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
 
     private readonly List<IDisposable> _subs = [];
     private readonly object _volumeMeterLock = new();
+
+    private readonly Dictionary<string, (double Level, DateTimeOffset UpdatedAt)> _volumeTargets =
+        new(StringComparer.OrdinalIgnoreCase);
+
     private ObsIntegrationSettings _settings = new();
     private CancellationTokenSource? _refreshCts;
     private DateTimeOffset _lastAutoConnectAttempt = DateTimeOffset.MinValue;
-    private DateTimeOffset _lastVolumeMeterEventAt = DateTimeOffset.MinValue;
     private bool _initialized;
     private bool _refreshing;
     private bool _refreshQueued;
-    private string? _activeMicrophoneName;
-    private bool? _currentMicrophoneMuted;
-    private double _targetVolumeMeterLevel;
-    private double _currentVolumeMeterLevel;
     private ToolStripLabel? _connectionStatusLabel;
     private ToolStripButton? _refreshButton;
 
@@ -114,41 +113,44 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         _ = RefreshSnapshotAsync(connectIfNeeded: ShouldTryAutoConnect());
     }
 
-    private void OnVolumeMeterPanelResize(object? sender, EventArgs e)
-    {
-        ApplyVolumeMeterLevel(_currentVolumeMeterLevel);
-    }
-
     private void OnVolumeMeterTimerTick(object? sender, EventArgs e)
     {
-        var target = ReadVolumeMeterTarget();
-        if (target <= 0D && _currentVolumeMeterLevel <= 0D)
+        if (_sourcesLayoutPanel.Controls.Count == 0)
         {
             return;
         }
 
         var delayMs = ResolveVolumeMeterDelayMs();
-        var alpha = Math.Clamp((double)_volumeMeterTimer.Interval / delayMs, 0.02D, 1D);
 
-        if (target > _currentVolumeMeterLevel)
+        foreach (var meter in _sourcesLayoutPanel.Controls.OfType<ObsSourceMeter>())
         {
-            alpha = Math.Clamp(alpha * 1.8D, 0.02D, 1D);
-        }
+            var target = ReadRowTarget(meter.SourceName, meter.Muted, meter.Found, delayMs);
+            if (target <= 0D && meter.CurrentLevel <= 0D)
+            {
+                continue;
+            }
 
-        var nextLevel = _currentVolumeMeterLevel + (target - _currentVolumeMeterLevel) * alpha;
-        if (Math.Abs(nextLevel - target) < 0.003D)
-        {
-            nextLevel = target;
-        }
+            var alpha = Math.Clamp((double)_volumeMeterTimer.Interval / delayMs, 0.02D, 1D);
+            if (target > meter.CurrentLevel)
+            {
+                alpha = Math.Clamp(alpha * 1.8D, 0.02D, 1D);
+            }
 
-        ApplyVolumeMeterLevel(nextLevel);
+            var nextLevel = meter.CurrentLevel + (target - meter.CurrentLevel) * alpha;
+            if (Math.Abs(nextLevel - target) < 0.003D)
+            {
+                nextLevel = target;
+            }
+
+            meter.ApplyVolumeMeterLevel(nextLevel);
+        }
     }
 
     private void OnObsEventReceived(object? sender, ObsWebSocketEventArgs evt)
     {
         if (string.Equals(evt.EventType, "InputVolumeMeters", StringComparison.Ordinal))
         {
-            TryUpdateVolumeMeterFromObsEvent(evt);
+            UpdateVolumeTargetsFromObsEvent(evt);
             return;
         }
 
@@ -158,96 +160,6 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         }
 
         ScheduleRefreshFromObsEvent();
-    }
-
-    private static bool TryGetVolumeMeterLevel(JsonElement eventData, string inputName, out double level)
-    {
-        level = 0;
-
-        if (!eventData.TryGetProperty("inputs", out var inputs) || inputs.ValueKind != JsonValueKind.Array)
-        {
-            return false;
-        }
-
-        using var inputEnumerator = inputs.EnumerateArray();
-        while (inputEnumerator.MoveNext())
-        {
-            var input = inputEnumerator.Current;
-            if (!string.Equals(GetOptionalString(input, "inputName"), inputName, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            if (input.TryGetProperty("inputLevelsMul", out var levelsMul)
-                && TryGetMaxNumber(levelsMul, out var maxMultiplier))
-            {
-                level = Math.Clamp(maxMultiplier, 0D, 1D);
-                return true;
-            }
-
-            if (input.TryGetProperty("inputLevelsDb", out var levelsDb)
-                && TryGetMaxNumber(levelsDb, out var maxDecibels))
-            {
-                level = NormalizeDecibelsToMeter(maxDecibels);
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
-    }
-
-    private static bool TryGetMaxNumber(JsonElement element, out double max)
-    {
-        max = double.NegativeInfinity;
-
-        if (element.ValueKind == JsonValueKind.Number)
-        {
-            max = element.GetDouble();
-            return true;
-        }
-
-        if (element.ValueKind != JsonValueKind.Array)
-        {
-            return false;
-        }
-
-        var found = false;
-        using var childEnumerator = element.EnumerateArray();
-        while (childEnumerator.MoveNext())
-        {
-            var child = childEnumerator.Current;
-            if (!TryGetMaxNumber(child, out var childMax))
-            {
-                continue;
-            }
-
-            max = Math.Max(max, childMax);
-            found = true;
-        }
-
-        return found;
-    }
-
-    private static double NormalizeDecibelsToMeter(double decibels)
-    {
-        return Math.Clamp((decibels + 60D) / 60D, 0D, 1D);
-    }
-
-    private static Color ResolveVolumeMeterColor(double normalized)
-    {
-        if (normalized >= 0.9D)
-        {
-            return Color.Firebrick;
-        }
-
-        if (normalized >= 0.68D)
-        {
-            return Color.DarkOrange;
-        }
-
-        return Color.SeaGreen;
     }
 
     private static string ToDisplayValue(string? value)
@@ -294,13 +206,118 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         };
     }
 
+    private static bool TryGetMaxNumber(JsonElement element, out double max)
+    {
+        max = double.NegativeInfinity;
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            max = element.GetDouble();
+            return true;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var found = false;
+        using var childEnumerator = element.EnumerateArray();
+        while (childEnumerator.MoveNext())
+        {
+            var child = childEnumerator.Current;
+            if (!TryGetMaxNumber(child, out var childMax))
+            {
+                continue;
+            }
+
+            max = Math.Max(max, childMax);
+            found = true;
+        }
+
+        return found;
+    }
+
+    private static bool TryGetInputLevel(JsonElement input, out double level)
+    {
+        level = 0;
+
+        if (input.TryGetProperty("inputLevelsMul", out var levelsMul)
+            && TryGetMaxNumber(levelsMul, out var maxMultiplier))
+        {
+            level = Math.Clamp(maxMultiplier, 0D, 1D);
+            return true;
+        }
+
+        if (input.TryGetProperty("inputLevelsDb", out var levelsDb)
+            && TryGetMaxNumber(levelsDb, out var maxDecibels))
+        {
+            level = NormalizeDecibelsToMeter(maxDecibels);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static double NormalizeDecibelsToMeter(double decibels)
+    {
+        return Math.Clamp((decibels + 60D) / 60D, 0D, 1D);
+    }
+
     private void OnObsIntegrationSettingsChanged(ObsIntegrationSettingsChangedEvent evt)
     {
         _settings = evt.Settings;
         _lastAutoConnectAttempt = DateTimeOffset.MinValue;
-        ResetVolumeMeterLevel();
+        ClearRows();
         ApplyCurrentConnectionState();
         _ = RefreshSnapshotAsync(connectIfNeeded: ShouldTryAutoConnect());
+    }
+
+    private void UpdateVolumeTargetsFromObsEvent(ObsWebSocketEventArgs evt)
+    {
+        if (evt.EventData is not { } eventData
+            || !eventData.TryGetProperty("inputs", out var inputs)
+            || inputs.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.Now;
+
+        lock (_volumeMeterLock)
+        {
+            using var inputEnumerator = inputs.EnumerateArray();
+            while (inputEnumerator.MoveNext())
+            {
+                var input = inputEnumerator.Current;
+                var inputName = GetOptionalString(input, "inputName");
+                if (string.IsNullOrWhiteSpace(inputName) || !TryGetInputLevel(input, out var level))
+                {
+                    continue;
+                }
+
+                _volumeTargets[inputName] = (level, now);
+            }
+        }
+    }
+
+    private double ReadRowTarget(string name, bool muted, bool found, int delayMs)
+    {
+        if (!found || muted || string.IsNullOrWhiteSpace(name))
+        {
+            return 0D;
+        }
+
+        lock (_volumeMeterLock)
+        {
+            if (!_volumeTargets.TryGetValue(name, out var target))
+            {
+                return 0D;
+            }
+
+            var staleAfter = TimeSpan.FromMilliseconds(delayMs * 3D);
+            return DateTimeOffset.Now - target.UpdatedAt > staleAfter ? 0D : target.Level;
+        }
     }
 
     private async Task RefreshSnapshotAsync(bool connectIfNeeded)
@@ -418,7 +435,125 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         _recordingLabel.Text = $"Запись: {FormatActiveState(snapshot.IsRecording)}";
         _recordingLabel.ForeColor = ResolveActiveColor(snapshot.IsRecording);
 
-        ApplyMicrophone(snapshot.Microphone, _settings.DashboardMicrophoneName);
+        ApplyAudioSources(snapshot.AudioSources);
+    }
+
+    private void ApplyAudioSources(IReadOnlyList<ObsAudioSourceSnapshot> audioSources)
+    {
+        var configured = _settings.GetDashboardSourceNames();
+        var orderedNames = configured.Count > 0
+            ? configured.ToList()
+            : audioSources.Select(source => source.Name).ToList();
+
+        EnsureRows(orderedNames);
+
+        foreach (var meter in _sourcesLayoutPanel.Controls.OfType<ObsSourceMeter>())
+        {
+            var snapshot = audioSources.FirstOrDefault(source =>
+                string.Equals(source.Name, meter.SourceName, StringComparison.OrdinalIgnoreCase));
+
+            if (snapshot is null)
+            {
+                meter.Found = false;
+                meter.Muted = false;
+                meter.ShowMissing(meter.SourceName);
+                continue;
+            }
+
+            meter.Found = true;
+            meter.Muted = snapshot.IsMuted;
+
+            if (snapshot.IsMuted)
+            {
+                meter.ShowMuted(snapshot.Name, snapshot.VolumeDecibels);
+            }
+            else
+            {
+                meter.ShowActive(snapshot.Name, snapshot.VolumeDecibels);
+            }
+        }
+    }
+
+    private void EnsureRows(IReadOnlyList<string> orderedNames)
+    {
+        var currentNames = _sourcesLayoutPanel.Controls
+            .OfType<ObsSourceMeter>()
+            .Select(meter => meter.SourceName);
+
+        if (currentNames.SequenceEqual(orderedNames, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _sourcesLayoutPanel.SuspendLayout();
+
+        try
+        {
+            foreach (var child in _sourcesLayoutPanel.Controls.Cast<Control>().ToList())
+            {
+                child.Dispose();
+            }
+
+            _sourcesLayoutPanel.Controls.Clear();
+            _sourcesLayoutPanel.RowStyles.Clear();
+
+            if (orderedNames.Count == 0)
+            {
+                _sourcesLayoutPanel.RowCount = 1;
+                _sourcesLayoutPanel.RowStyles.Add(new(SizeType.Absolute, 0F));
+                return;
+            }
+
+            _sourcesLayoutPanel.RowCount = orderedNames.Count;
+
+            for (var index = 0; index < orderedNames.Count; index++)
+            {
+                var meter = new ObsSourceMeter
+                {
+                    SourceName = orderedNames[index],
+                    Dock = DockStyle.Top,
+                };
+
+                _sourcesLayoutPanel.RowStyles.Add(new(SizeType.AutoSize));
+                _sourcesLayoutPanel.Controls.Add(meter, 0, index);
+            }
+        }
+        finally
+        {
+            _sourcesLayoutPanel.ResumeLayout(true);
+        }
+
+        lock (_volumeMeterLock)
+        {
+            _volumeTargets.Clear();
+        }
+    }
+
+    private void ClearRows()
+    {
+        _sourcesLayoutPanel.SuspendLayout();
+
+        try
+        {
+            foreach (var child in _sourcesLayoutPanel.Controls.Cast<Control>().ToList())
+            {
+                child.Dispose();
+            }
+
+            _sourcesLayoutPanel.Controls.Clear();
+            _sourcesLayoutPanel.RowStyles.Clear();
+            _sourcesLayoutPanel.RowCount = 1;
+            _sourcesLayoutPanel.RowStyles.Add(new(SizeType.Absolute, 0F));
+        }
+        finally
+        {
+            _sourcesLayoutPanel.ResumeLayout(true);
+        }
+
+        lock (_volumeMeterLock)
+        {
+            _volumeTargets.Clear();
+        }
     }
 
     private void ApplyDisabledState()
@@ -436,47 +571,6 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         ResetDetails("—");
     }
 
-    private void ApplyMicrophone(ObsMicrophoneSnapshot? microphone, string configuredMicrophoneName)
-    {
-        if (microphone is null)
-        {
-            _activeMicrophoneName = null;
-            _currentMicrophoneMuted = null;
-            SetMicrophoneState("МИКРОФОН НЕ НАЙДЕН",
-                Color.DarkOrange,
-                Color.Black);
-
-            ResetVolumeMeterLevel();
-            _microphoneLabel.Text = string.IsNullOrWhiteSpace(configuredMicrophoneName)
-                ? "Микрофон: не найден"
-                : $"Микрофон: {configuredMicrophoneName.Trim()} не найден";
-
-            _microphoneLabel.ForeColor = Color.Orange;
-            return;
-        }
-
-        _activeMicrophoneName = microphone.Name;
-        _currentMicrophoneMuted = microphone.IsMuted;
-        SetMicrophoneState(microphone.IsMuted ? "МИКРОФОН ВЫКЛЮЧЕН" : "МИКРОФОН ВКЛЮЧЕН",
-            microphone.IsMuted ? Color.Firebrick : Color.SeaGreen,
-            Color.White);
-
-        if (microphone.IsMuted)
-        {
-            ResetVolumeMeterLevel();
-        }
-
-        var volume = microphone.VolumeDecibels.HasValue
-            ? $" · {microphone.VolumeDecibels.Value:0.#} дБ"
-            : string.Empty;
-
-        _microphoneLabel.Text = microphone.IsMuted
-            ? $"Микрофон: выключен · {microphone.Name}{volume}"
-            : $"Микрофон: включен · {microphone.Name}{volume}";
-
-        _microphoneLabel.ForeColor = microphone.IsMuted ? Color.Red : Color.Green;
-    }
-
     private void ResetDetails(string value)
     {
         _sceneLabel.Text = $"Сцена: {value}";
@@ -484,12 +578,7 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         _streamingLabel.ForeColor = Color.DimGray;
         _recordingLabel.Text = $"Запись: {value}";
         _recordingLabel.ForeColor = Color.DimGray;
-        _activeMicrophoneName = null;
-        _currentMicrophoneMuted = null;
-        SetMicrophoneState("МИКРОФОН —", Color.Gray, Color.White);
-        ResetVolumeMeterLevel();
-        _microphoneLabel.Text = $"Микрофон: {value}";
-        _microphoneLabel.ForeColor = Color.DimGray;
+        ClearRows();
     }
 
     private void UpdateConnectionHeader(string text, Color color, string toolTipText)
@@ -502,90 +591,6 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         _connectionStatusLabel.Text = text;
         _connectionStatusLabel.ForeColor = color;
         _connectionStatusLabel.ToolTipText = toolTipText;
-    }
-
-    private void SetMicrophoneState(string text, Color backColor, Color foreColor)
-    {
-        _microphoneStateLabel.Text = text;
-        _microphoneStateLabel.BackColor = backColor;
-        _microphoneStateLabel.ForeColor = foreColor;
-    }
-
-    private void TryUpdateVolumeMeterFromObsEvent(ObsWebSocketEventArgs evt)
-    {
-        if (_currentMicrophoneMuted == true)
-        {
-            SetVolumeMeterTarget(0);
-            return;
-        }
-
-        if (evt.EventData is not { } eventData)
-        {
-            return;
-        }
-
-        var microphoneName = ResolveVolumeMeterInputName();
-        if (string.IsNullOrWhiteSpace(microphoneName))
-        {
-            return;
-        }
-
-        if (!TryGetVolumeMeterLevel(eventData, microphoneName, out var level))
-        {
-            return;
-        }
-
-        SetVolumeMeterTarget(level);
-    }
-
-    private string? ResolveVolumeMeterInputName()
-    {
-        return string.IsNullOrWhiteSpace(_settings.DashboardMicrophoneName)
-            ? _activeMicrophoneName
-            : _settings.DashboardMicrophoneName.Trim();
-    }
-
-    private double ReadVolumeMeterTarget()
-    {
-        lock (_volumeMeterLock)
-        {
-            var delayMs = ResolveVolumeMeterDelayMs();
-            var staleAfter = TimeSpan.FromMilliseconds(delayMs * 3D);
-            return _lastVolumeMeterEventAt == DateTimeOffset.MinValue
-                   || DateTimeOffset.Now - _lastVolumeMeterEventAt > staleAfter
-                ? 0D
-                : _targetVolumeMeterLevel;
-        }
-    }
-
-    private void SetVolumeMeterTarget(double level)
-    {
-        lock (_volumeMeterLock)
-        {
-            _targetVolumeMeterLevel = Math.Clamp(level, 0D, 1D);
-            _lastVolumeMeterEventAt = DateTimeOffset.Now;
-        }
-    }
-
-    private void ResetVolumeMeterLevel()
-    {
-        lock (_volumeMeterLock)
-        {
-            _targetVolumeMeterLevel = 0D;
-            _lastVolumeMeterEventAt = DateTimeOffset.MinValue;
-        }
-
-        ApplyVolumeMeterLevel(0);
-    }
-
-    private void ApplyVolumeMeterLevel(double level)
-    {
-        var normalized = Math.Clamp(level, 0D, 1D);
-        _currentVolumeMeterLevel = normalized;
-        var width = (int)Math.Round(_volumeMeterPanel.ClientSize.Width * normalized);
-
-        _volumeMeterFillPanel.Width = Math.Max(0, width);
-        _volumeMeterFillPanel.BackColor = ResolveVolumeMeterColor(normalized);
     }
 
     private int ResolveVolumeMeterDelayMs()

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
@@ -6,6 +6,7 @@ using PoproshaykaBot.Core.Settings.Obs;
 using PoproshaykaBot.Core.Settings.Stores;
 using PoproshaykaBot.WinForms.Infrastructure.Di;
 using PoproshaykaBot.WinForms.Tiles;
+using System.Globalization;
 using System.Text.Json;
 
 namespace PoproshaykaBot.WinForms.Widgets;
@@ -93,6 +94,9 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         _initialized = true;
         _settings = Store.Load();
 
+        _streamStatusCard.Configure(ObsOutputCardKind.Stream);
+        _recordStatusCard.Configure(ObsOutputCardKind.Record);
+
         _subs.Add(Bus.SubscribeOnUi<ObsIntegrationSettingsChangedEvent>(this, OnObsIntegrationSettingsChanged));
         ObsClient.EventReceived += OnObsEventReceived;
         _subs.Add(new Subscription(() => ObsClient.EventReceived -= OnObsEventReceived));
@@ -165,6 +169,55 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private static string ToDisplayValue(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? "—" : value;
+    }
+
+    private static (string Text, ObsCardChipTone Tone)? FormatStreamHealth(
+        bool? active,
+        double? congestion,
+        long? skippedFrames,
+        long? totalFrames)
+    {
+        if (active != true)
+        {
+            return null;
+        }
+
+        if (skippedFrames is > 0 && totalFrames is > 0)
+        {
+            var ratio = (double)skippedFrames.Value / totalFrames.Value;
+            if (ratio >= 0.001D)
+            {
+                return (string.Create(CultureInfo.InvariantCulture,
+                    $"дропы · {skippedFrames.Value} ({ratio * 100D:0.0}%)"), ObsCardChipTone.Bad);
+            }
+        }
+
+        if (congestion is > 0.05D)
+        {
+            return (string.Create(CultureInfo.InvariantCulture,
+                $"сеть · {congestion.Value * 100D:0}%"), ObsCardChipTone.Warn);
+        }
+
+        return ("стабильно", ObsCardChipTone.Ok);
+    }
+
+    private static string? FormatRecordBytes(bool? active, long? bytes)
+    {
+        if (active != true || bytes is null or <= 0)
+        {
+            return null;
+        }
+
+        var value = bytes.Value;
+        return value switch
+        {
+            >= 1L << 30 => string.Create(CultureInfo.InvariantCulture,
+                $"{value / (double)(1L << 30):0.##} ГБ"),
+            >= 1L << 20 => string.Create(CultureInfo.InvariantCulture,
+                $"{value / (double)(1L << 20):0.#} МБ"),
+            _ => string.Create(CultureInfo.InvariantCulture,
+                $"{value / 1024D:0} КБ"),
+        };
     }
 
     private static string? GetOptionalString(JsonElement element, string propertyName)
@@ -410,8 +463,23 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         UpdateConnectionHeader("● OBS подключён", Color.Green, "OBS WebSocket подключён");
 
         _sceneLabel.Text = $"Сцена: {ToDisplayValue(snapshot.CurrentSceneName)}";
-        _streamStatusCard.Show("Эфир", snapshot.IsStreaming, null, snapshot.StreamTimecode);
-        _recordStatusCard.Show("Запись", snapshot.IsRecording, snapshot.IsRecordingPaused, snapshot.RecordTimecode);
+
+        var streamHealth = FormatStreamHealth(snapshot.IsStreaming,
+            snapshot.StreamCongestion,
+            snapshot.StreamSkippedFrames,
+            snapshot.StreamTotalFrames);
+
+        _streamStatusCard.ApplySnapshot(snapshot.IsStreaming,
+            null,
+            snapshot.StreamTimecode,
+            null,
+            streamHealth?.Text,
+            streamHealth?.Tone ?? ObsCardChipTone.Neutral);
+
+        _recordStatusCard.ApplySnapshot(snapshot.IsRecording,
+            snapshot.IsRecordingPaused,
+            snapshot.RecordTimecode,
+            FormatRecordBytes(snapshot.IsRecording, snapshot.RecordBytes));
 
         ApplyAudioSources(snapshot.AudioSources);
     }
@@ -537,7 +605,10 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private void ApplyDisabledState()
     {
         UpdateConnectionHeader("○ OBS выкл.", Color.Gray, "OBS интеграция отключена в настройках");
-        ResetDetails("—");
+        _sceneLabel.Text = "Сцена: —";
+        _streamStatusCard.ApplyUnknown();
+        _recordStatusCard.ApplyUnknown();
+        ClearRows();
     }
 
     private void ApplyUnavailableState(string? message)
@@ -546,14 +617,9 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
             Color.Red,
             string.IsNullOrWhiteSpace(message) ? "OBS WebSocket не подключён" : $"OBS WebSocket не подключён: {message}");
 
-        ResetDetails("—");
-    }
-
-    private void ResetDetails(string value)
-    {
-        _sceneLabel.Text = $"Сцена: {value}";
-        _streamStatusCard.Show("Эфир", null, null, null);
-        _recordStatusCard.Show("Запись", null, null, null);
+        _sceneLabel.Text = "Сцена: —";
+        _streamStatusCard.ApplyUnavailable(message);
+        _recordStatusCard.ApplyUnavailable(message);
         ClearRows();
     }
 

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
@@ -186,26 +186,6 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
             or "InputRemoved";
     }
 
-    private static string FormatActiveState(bool? active)
-    {
-        return active switch
-        {
-            true => "идёт",
-            false => "нет",
-            _ => "—",
-        };
-    }
-
-    private static Color ResolveActiveColor(bool? active)
-    {
-        return active switch
-        {
-            true => Color.Green,
-            false => Color.DimGray,
-            _ => Color.Orange,
-        };
-    }
-
     private static bool TryGetMaxNumber(JsonElement element, out double max)
     {
         max = double.NegativeInfinity;
@@ -430,10 +410,8 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         UpdateConnectionHeader("● OBS подключён", Color.Green, "OBS WebSocket подключён");
 
         _sceneLabel.Text = $"Сцена: {ToDisplayValue(snapshot.CurrentSceneName)}";
-        _streamingLabel.Text = $"Эфир: {FormatActiveState(snapshot.IsStreaming)}";
-        _streamingLabel.ForeColor = ResolveActiveColor(snapshot.IsStreaming);
-        _recordingLabel.Text = $"Запись: {FormatActiveState(snapshot.IsRecording)}";
-        _recordingLabel.ForeColor = ResolveActiveColor(snapshot.IsRecording);
+        _streamStatusCard.Show("Эфир", snapshot.IsStreaming, null, snapshot.StreamTimecode);
+        _recordStatusCard.Show("Запись", snapshot.IsRecording, snapshot.IsRecordingPaused, snapshot.RecordTimecode);
 
         ApplyAudioSources(snapshot.AudioSources);
     }
@@ -574,10 +552,8 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private void ResetDetails(string value)
     {
         _sceneLabel.Text = $"Сцена: {value}";
-        _streamingLabel.Text = $"Эфир: {value}";
-        _streamingLabel.ForeColor = Color.DimGray;
-        _recordingLabel.Text = $"Запись: {value}";
-        _recordingLabel.ForeColor = Color.DimGray;
+        _streamStatusCard.Show("Эфир", null, null, null);
+        _recordStatusCard.Show("Запись", null, null, null);
         ClearRows();
     }
 

--- a/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsInfoWidget.cs
@@ -33,6 +33,7 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private bool _refreshQueued;
     private ToolStripLabel? _connectionStatusLabel;
     private ToolStripButton? _refreshButton;
+    private ToolStripButton? _refreshChatSourcesButton;
 
     public ObsInfoWidget()
     {
@@ -74,7 +75,17 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
         };
 
         _refreshButton.Click += OnRefreshClick;
-        return [_connectionStatusLabel, _refreshButton];
+
+        _refreshChatSourcesButton = new()
+        {
+            AutoToolTip = false,
+            DisplayStyle = ToolStripItemDisplayStyle.Text,
+            Text = "🔁",
+            ToolTipText = "Жёстко обновить чат-источники OBS (refreshnocache)",
+        };
+
+        _refreshChatSourcesButton.Click += OnRefreshChatSourcesClick;
+        return [_connectionStatusLabel, _refreshButton, _refreshChatSourcesButton];
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -110,6 +121,11 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private void OnRefreshClick(object? sender, EventArgs e)
     {
         _ = RefreshSnapshotAsync(connectIfNeeded: true);
+    }
+
+    private void OnRefreshChatSourcesClick(object? sender, EventArgs e)
+    {
+        _ = RefreshChatSourcesAsync();
     }
 
     private void OnRefreshTimerTick(object? sender, EventArgs e)
@@ -295,6 +311,112 @@ public sealed partial class ObsInfoWidget : UserControl, IDashboardTileHeaderPro
     private static double NormalizeDecibelsToMeter(double decibels)
     {
         return Math.Clamp((decibels + 60D) / 60D, 0D, 1D);
+    }
+
+    private async Task RefreshChatSourcesAsync()
+    {
+        if (_refreshChatSourcesButton is null || IsDisposed)
+        {
+            return;
+        }
+
+        _refreshChatSourcesButton.Enabled = false;
+
+        var configuredCount = _settings.GetChatRefreshSourceNames().Count;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            var refreshed = await ObsIntegration.RefreshConfiguredChatSourcesAsync(_settings, cts.Token);
+
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            if (configuredCount == 0)
+            {
+                ShowChatRefreshToast("🔁 источники не настроены", Color.DarkOrange);
+                Logger.LogInformation("Чат-источники для refresh не настроены");
+            }
+            else if (refreshed == 0)
+            {
+                ShowChatRefreshToast($"🔁 ни один из {configuredCount} не обновлён", Color.DarkRed);
+                Logger.LogWarning("Ручной refresh: OBS отклонил все {Count} запросов — проверьте имена источников", configuredCount);
+            }
+            else if (refreshed < configuredCount)
+            {
+                ShowChatRefreshToast($"🔁 обновлено {refreshed}/{configuredCount}", Color.DarkOrange);
+            }
+            else
+            {
+                ShowChatRefreshToast($"🔁 обновлено: {refreshed}", Color.DarkGreen);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            ShowChatRefreshToast("🔁 таймаут", Color.DarkRed);
+            Logger.LogWarning("Ручной refresh чат-источников OBS: превышено время ожидания");
+        }
+        catch (Exception exception)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            ShowChatRefreshToast("🔁 ошибка", Color.DarkRed);
+            Logger.LogWarning(exception, "Не удалось обновить чат-источники OBS вручную");
+        }
+        finally
+        {
+            if (!IsDisposed && _refreshChatSourcesButton is not null)
+            {
+                _refreshChatSourcesButton.Enabled = true;
+            }
+        }
+    }
+
+    private void ShowChatRefreshToast(string text, Color color)
+    {
+        if (_connectionStatusLabel is null || IsDisposed)
+        {
+            return;
+        }
+
+        var previousText = _connectionStatusLabel.Text;
+        var previousColor = _connectionStatusLabel.ForeColor;
+        var previousTooltip = _connectionStatusLabel.ToolTipText;
+
+        _connectionStatusLabel.Text = text;
+        _connectionStatusLabel.ForeColor = color;
+        _connectionStatusLabel.ToolTipText = text;
+
+        _ = RestoreConnectionLabelAfterDelayAsync(previousText, previousColor, previousTooltip);
+    }
+
+    private async Task RestoreConnectionLabelAfterDelayAsync(string previousText, Color previousColor, string previousTooltip)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(4));
+
+        if (IsDisposed || _connectionStatusLabel is null)
+        {
+            return;
+        }
+
+        ApplyCurrentConnectionState();
+
+        if (_connectionStatusLabel.Text == previousText)
+        {
+            return;
+        }
+
+        _connectionStatusLabel.ToolTipText = previousTooltip;
     }
 
     private void OnObsIntegrationSettingsChanged(ObsIntegrationSettingsChangedEvent evt)

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputCardKind.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputCardKind.cs
@@ -1,0 +1,7 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+public enum ObsOutputCardKind
+{
+    Stream = 0,
+    Record = 1,
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputCardState.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputCardState.cs
@@ -1,0 +1,10 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+public enum ObsOutputCardState
+{
+    Unknown = 0,
+    Idle = 1,
+    Active = 2,
+    Paused = 3,
+    Error = 4,
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.Designer.cs
@@ -1,0 +1,99 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+sealed partial class ObsOutputStatusCard
+{
+    private System.ComponentModel.IContainer components = null;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            components?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void InitializeComponent()
+    {
+        _layoutTableLayoutPanel = new TableLayoutPanel();
+        _titleLabel = new Label();
+        _stateLabel = new Label();
+        _timecodeLabel = new Label();
+        _layoutTableLayoutPanel.SuspendLayout();
+        SuspendLayout();
+        //
+        // _layoutTableLayoutPanel
+        //
+        _layoutTableLayoutPanel.ColumnCount = 1;
+        _layoutTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _layoutTableLayoutPanel.Controls.Add(_titleLabel, 0, 0);
+        _layoutTableLayoutPanel.Controls.Add(_stateLabel, 0, 1);
+        _layoutTableLayoutPanel.Controls.Add(_timecodeLabel, 0, 2);
+        _layoutTableLayoutPanel.Dock = DockStyle.Fill;
+        _layoutTableLayoutPanel.Location = new Point(0, 0);
+        _layoutTableLayoutPanel.Margin = new Padding(0);
+        _layoutTableLayoutPanel.Name = "_layoutTableLayoutPanel";
+        _layoutTableLayoutPanel.RowCount = 3;
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 18F));
+        _layoutTableLayoutPanel.Size = new Size(180, 76);
+        _layoutTableLayoutPanel.TabIndex = 0;
+        //
+        // _titleLabel
+        //
+        _titleLabel.Dock = DockStyle.Fill;
+        _titleLabel.ForeColor = Color.DimGray;
+        _titleLabel.Location = new Point(0, 0);
+        _titleLabel.Margin = new Padding(0);
+        _titleLabel.Name = "_titleLabel";
+        _titleLabel.Size = new Size(180, 20);
+        _titleLabel.TabIndex = 0;
+        _titleLabel.Text = "—";
+        _titleLabel.TextAlign = ContentAlignment.MiddleCenter;
+        //
+        // _stateLabel
+        //
+        _stateLabel.AutoEllipsis = true;
+        _stateLabel.Dock = DockStyle.Fill;
+        _stateLabel.Font = new Font("Segoe UI", 12F, FontStyle.Bold);
+        _stateLabel.ForeColor = Color.Gray;
+        _stateLabel.Location = new Point(0, 20);
+        _stateLabel.Margin = new Padding(0);
+        _stateLabel.Name = "_stateLabel";
+        _stateLabel.Size = new Size(180, 38);
+        _stateLabel.TabIndex = 1;
+        _stateLabel.Text = "—";
+        _stateLabel.TextAlign = ContentAlignment.MiddleCenter;
+        //
+        // _timecodeLabel
+        //
+        _timecodeLabel.Dock = DockStyle.Fill;
+        _timecodeLabel.ForeColor = Color.DimGray;
+        _timecodeLabel.Location = new Point(0, 58);
+        _timecodeLabel.Margin = new Padding(0);
+        _timecodeLabel.Name = "_timecodeLabel";
+        _timecodeLabel.Size = new Size(180, 18);
+        _timecodeLabel.TabIndex = 2;
+        _timecodeLabel.Text = string.Empty;
+        _timecodeLabel.TextAlign = ContentAlignment.MiddleCenter;
+        _timecodeLabel.Visible = false;
+        //
+        // ObsOutputStatusCard
+        //
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        Controls.Add(_layoutTableLayoutPanel);
+        Margin = new Padding(0);
+        Name = "ObsOutputStatusCard";
+        Size = new Size(180, 76);
+        _layoutTableLayoutPanel.ResumeLayout(false);
+        ResumeLayout(false);
+    }
+
+    private TableLayoutPanel _layoutTableLayoutPanel;
+    private Label _titleLabel;
+    private Label _stateLabel;
+    private Label _timecodeLabel;
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.Designer.cs
@@ -16,84 +16,277 @@ sealed partial class ObsOutputStatusCard
 
     private void InitializeComponent()
     {
+        components = new System.ComponentModel.Container();
         _layoutTableLayoutPanel = new TableLayoutPanel();
-        _titleLabel = new Label();
+        _topLeftLayoutPanel = new TableLayoutPanel();
+        _kickerLabel = new Label();
+        _stateRowLayoutPanel = new TableLayoutPanel();
+        _dotPanel = new Panel();
         _stateLabel = new Label();
+        _topRightLayoutPanel = new TableLayoutPanel();
+        _kickerRightLabel = new Label();
         _timecodeLabel = new Label();
+        _metaLabel = new Label();
+        _primaryButton = new Button();
+        _secondaryWrapPanel = new Panel();
+        _secondaryButton = new Button();
+        _secondaryChipLabel = new Label();
+        _pulseTimer = new System.Windows.Forms.Timer(components);
         _layoutTableLayoutPanel.SuspendLayout();
+        _topLeftLayoutPanel.SuspendLayout();
+        _stateRowLayoutPanel.SuspendLayout();
+        _topRightLayoutPanel.SuspendLayout();
+        _secondaryWrapPanel.SuspendLayout();
         SuspendLayout();
         //
         // _layoutTableLayoutPanel
         //
-        _layoutTableLayoutPanel.ColumnCount = 1;
-        _layoutTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-        _layoutTableLayoutPanel.Controls.Add(_titleLabel, 0, 0);
-        _layoutTableLayoutPanel.Controls.Add(_stateLabel, 0, 1);
-        _layoutTableLayoutPanel.Controls.Add(_timecodeLabel, 0, 2);
+        _layoutTableLayoutPanel.ColumnCount = 2;
+        _layoutTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        _layoutTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        _layoutTableLayoutPanel.Controls.Add(_topLeftLayoutPanel, 0, 0);
+        _layoutTableLayoutPanel.Controls.Add(_topRightLayoutPanel, 1, 0);
+        _layoutTableLayoutPanel.Controls.Add(_primaryButton, 0, 1);
+        _layoutTableLayoutPanel.Controls.Add(_secondaryWrapPanel, 1, 1);
         _layoutTableLayoutPanel.Dock = DockStyle.Fill;
-        _layoutTableLayoutPanel.Location = new Point(0, 0);
+        _layoutTableLayoutPanel.Location = new Point(2, 2);
         _layoutTableLayoutPanel.Margin = new Padding(0);
         _layoutTableLayoutPanel.Name = "_layoutTableLayoutPanel";
-        _layoutTableLayoutPanel.RowCount = 3;
-        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 18F));
-        _layoutTableLayoutPanel.Size = new Size(180, 76);
+        _layoutTableLayoutPanel.Padding = new Padding(4);
+        _layoutTableLayoutPanel.RowCount = 2;
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        _layoutTableLayoutPanel.Size = new Size(176, 156);
         _layoutTableLayoutPanel.TabIndex = 0;
         //
-        // _titleLabel
+        // _topLeftLayoutPanel
         //
-        _titleLabel.Dock = DockStyle.Fill;
-        _titleLabel.ForeColor = Color.DimGray;
-        _titleLabel.Location = new Point(0, 0);
-        _titleLabel.Margin = new Padding(0);
-        _titleLabel.Name = "_titleLabel";
-        _titleLabel.Size = new Size(180, 20);
-        _titleLabel.TabIndex = 0;
-        _titleLabel.Text = "—";
-        _titleLabel.TextAlign = ContentAlignment.MiddleCenter;
+        _topLeftLayoutPanel.ColumnCount = 1;
+        _topLeftLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _topLeftLayoutPanel.Controls.Add(_kickerLabel, 0, 0);
+        _topLeftLayoutPanel.Controls.Add(_stateRowLayoutPanel, 0, 1);
+        _topLeftLayoutPanel.Dock = DockStyle.Fill;
+        _topLeftLayoutPanel.Location = new Point(7, 7);
+        _topLeftLayoutPanel.Margin = new Padding(3, 3, 3, 3);
+        _topLeftLayoutPanel.Name = "_topLeftLayoutPanel";
+        _topLeftLayoutPanel.RowCount = 2;
+        _topLeftLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 16F));
+        _topLeftLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _topLeftLayoutPanel.Size = new Size(78, 68);
+        _topLeftLayoutPanel.TabIndex = 0;
+        //
+        // _kickerLabel
+        //
+        _kickerLabel.AutoEllipsis = true;
+        _kickerLabel.Dock = DockStyle.Fill;
+        _kickerLabel.Font = new Font("Segoe UI", 7.5F, FontStyle.Bold);
+        _kickerLabel.ForeColor = Color.Gray;
+        _kickerLabel.Location = new Point(0, 0);
+        _kickerLabel.Margin = new Padding(0);
+        _kickerLabel.Name = "_kickerLabel";
+        _kickerLabel.Size = new Size(78, 16);
+        _kickerLabel.TabIndex = 0;
+        _kickerLabel.Text = "СТАТУС";
+        _kickerLabel.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // _stateRowLayoutPanel
+        //
+        _stateRowLayoutPanel.ColumnCount = 2;
+        _stateRowLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 18F));
+        _stateRowLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _stateRowLayoutPanel.Controls.Add(_dotPanel, 0, 0);
+        _stateRowLayoutPanel.Controls.Add(_stateLabel, 1, 0);
+        _stateRowLayoutPanel.Dock = DockStyle.Fill;
+        _stateRowLayoutPanel.Location = new Point(0, 16);
+        _stateRowLayoutPanel.Margin = new Padding(0);
+        _stateRowLayoutPanel.Name = "_stateRowLayoutPanel";
+        _stateRowLayoutPanel.RowCount = 1;
+        _stateRowLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _stateRowLayoutPanel.Size = new Size(78, 52);
+        _stateRowLayoutPanel.TabIndex = 1;
+        //
+        // _dotPanel
+        //
+        _dotPanel.BackColor = Color.Transparent;
+        _dotPanel.Dock = DockStyle.Fill;
+        _dotPanel.Location = new Point(0, 0);
+        _dotPanel.Margin = new Padding(0);
+        _dotPanel.Name = "_dotPanel";
+        _dotPanel.Size = new Size(18, 52);
+        _dotPanel.TabIndex = 0;
+        _dotPanel.Paint += OnDotPanelPaint;
         //
         // _stateLabel
         //
         _stateLabel.AutoEllipsis = true;
         _stateLabel.Dock = DockStyle.Fill;
-        _stateLabel.Font = new Font("Segoe UI", 12F, FontStyle.Bold);
+        _stateLabel.Font = new Font("Segoe UI", 11F, FontStyle.Bold);
         _stateLabel.ForeColor = Color.Gray;
-        _stateLabel.Location = new Point(0, 20);
+        _stateLabel.Location = new Point(18, 0);
         _stateLabel.Margin = new Padding(0);
         _stateLabel.Name = "_stateLabel";
-        _stateLabel.Size = new Size(180, 38);
+        _stateLabel.Size = new Size(60, 52);
         _stateLabel.TabIndex = 1;
         _stateLabel.Text = "—";
-        _stateLabel.TextAlign = ContentAlignment.MiddleCenter;
+        _stateLabel.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // _topRightLayoutPanel
+        //
+        _topRightLayoutPanel.ColumnCount = 1;
+        _topRightLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _topRightLayoutPanel.Controls.Add(_kickerRightLabel, 0, 0);
+        _topRightLayoutPanel.Controls.Add(_timecodeLabel, 0, 1);
+        _topRightLayoutPanel.Controls.Add(_metaLabel, 0, 2);
+        _topRightLayoutPanel.Dock = DockStyle.Fill;
+        _topRightLayoutPanel.Location = new Point(91, 7);
+        _topRightLayoutPanel.Margin = new Padding(3, 3, 3, 3);
+        _topRightLayoutPanel.Name = "_topRightLayoutPanel";
+        _topRightLayoutPanel.RowCount = 3;
+        _topRightLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 16F));
+        _topRightLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _topRightLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 14F));
+        _topRightLayoutPanel.Size = new Size(78, 68);
+        _topRightLayoutPanel.TabIndex = 1;
+        //
+        // _kickerRightLabel
+        //
+        _kickerRightLabel.AutoEllipsis = true;
+        _kickerRightLabel.Dock = DockStyle.Fill;
+        _kickerRightLabel.Font = new Font("Segoe UI", 7.5F, FontStyle.Bold);
+        _kickerRightLabel.ForeColor = Color.Gray;
+        _kickerRightLabel.Location = new Point(0, 0);
+        _kickerRightLabel.Margin = new Padding(0);
+        _kickerRightLabel.Name = "_kickerRightLabel";
+        _kickerRightLabel.Size = new Size(78, 16);
+        _kickerRightLabel.TabIndex = 0;
+        _kickerRightLabel.Text = "ТАЙМЕР";
+        _kickerRightLabel.TextAlign = ContentAlignment.MiddleRight;
         //
         // _timecodeLabel
         //
+        _timecodeLabel.AutoEllipsis = true;
         _timecodeLabel.Dock = DockStyle.Fill;
+        _timecodeLabel.Font = new Font("Consolas", 13F, FontStyle.Bold);
         _timecodeLabel.ForeColor = Color.DimGray;
-        _timecodeLabel.Location = new Point(0, 58);
+        _timecodeLabel.Location = new Point(0, 16);
         _timecodeLabel.Margin = new Padding(0);
         _timecodeLabel.Name = "_timecodeLabel";
-        _timecodeLabel.Size = new Size(180, 18);
-        _timecodeLabel.TabIndex = 2;
-        _timecodeLabel.Text = string.Empty;
-        _timecodeLabel.TextAlign = ContentAlignment.MiddleCenter;
-        _timecodeLabel.Visible = false;
+        _timecodeLabel.Size = new Size(78, 38);
+        _timecodeLabel.TabIndex = 1;
+        _timecodeLabel.Text = "—:—:—";
+        _timecodeLabel.TextAlign = ContentAlignment.MiddleRight;
+        //
+        // _metaLabel
+        //
+        _metaLabel.AutoEllipsis = true;
+        _metaLabel.Dock = DockStyle.Fill;
+        _metaLabel.Font = new Font("Segoe UI", 7.5F);
+        _metaLabel.ForeColor = Color.Gray;
+        _metaLabel.Location = new Point(0, 54);
+        _metaLabel.Margin = new Padding(0);
+        _metaLabel.Name = "_metaLabel";
+        _metaLabel.Size = new Size(78, 14);
+        _metaLabel.TabIndex = 2;
+        _metaLabel.Text = string.Empty;
+        _metaLabel.TextAlign = ContentAlignment.MiddleRight;
+        //
+        // _primaryButton
+        //
+        _primaryButton.Dock = DockStyle.Fill;
+        _primaryButton.FlatAppearance.BorderColor = Color.Silver;
+        _primaryButton.FlatAppearance.BorderSize = 1;
+        _primaryButton.FlatStyle = FlatStyle.Flat;
+        _primaryButton.Font = new Font("Segoe UI", 8.25F, FontStyle.Bold);
+        _primaryButton.Location = new Point(7, 81);
+        _primaryButton.Margin = new Padding(3, 3, 3, 3);
+        _primaryButton.Name = "_primaryButton";
+        _primaryButton.Size = new Size(78, 68);
+        _primaryButton.TabIndex = 2;
+        _primaryButton.Text = "—";
+        _primaryButton.UseVisualStyleBackColor = true;
+        _primaryButton.Click += OnPrimaryButtonClick;
+        //
+        // _secondaryWrapPanel
+        //
+        _secondaryWrapPanel.Controls.Add(_secondaryChipLabel);
+        _secondaryWrapPanel.Controls.Add(_secondaryButton);
+        _secondaryWrapPanel.Dock = DockStyle.Fill;
+        _secondaryWrapPanel.Location = new Point(91, 81);
+        _secondaryWrapPanel.Margin = new Padding(3, 3, 3, 3);
+        _secondaryWrapPanel.Name = "_secondaryWrapPanel";
+        _secondaryWrapPanel.Size = new Size(78, 68);
+        _secondaryWrapPanel.TabIndex = 3;
+        //
+        // _secondaryButton
+        //
+        _secondaryButton.Dock = DockStyle.Fill;
+        _secondaryButton.Enabled = false;
+        _secondaryButton.FlatAppearance.BorderColor = Color.Silver;
+        _secondaryButton.FlatAppearance.BorderSize = 1;
+        _secondaryButton.FlatStyle = FlatStyle.Flat;
+        _secondaryButton.Font = new Font("Segoe UI", 8.25F, FontStyle.Bold);
+        _secondaryButton.Location = new Point(0, 0);
+        _secondaryButton.Margin = new Padding(0);
+        _secondaryButton.Name = "_secondaryButton";
+        _secondaryButton.Size = new Size(78, 68);
+        _secondaryButton.TabIndex = 0;
+        _secondaryButton.Text = "—";
+        _secondaryButton.UseVisualStyleBackColor = true;
+        _secondaryButton.Click += OnSecondaryButtonClick;
+        //
+        // _secondaryChipLabel
+        //
+        _secondaryChipLabel.AutoEllipsis = true;
+        _secondaryChipLabel.BorderStyle = BorderStyle.FixedSingle;
+        _secondaryChipLabel.Dock = DockStyle.Fill;
+        _secondaryChipLabel.Font = new Font("Segoe UI", 8.25F, FontStyle.Bold);
+        _secondaryChipLabel.ForeColor = Color.Gray;
+        _secondaryChipLabel.Location = new Point(0, 0);
+        _secondaryChipLabel.Margin = new Padding(0);
+        _secondaryChipLabel.Name = "_secondaryChipLabel";
+        _secondaryChipLabel.Padding = new Padding(2);
+        _secondaryChipLabel.Size = new Size(78, 68);
+        _secondaryChipLabel.TabIndex = 1;
+        _secondaryChipLabel.Text = "—";
+        _secondaryChipLabel.TextAlign = ContentAlignment.MiddleCenter;
+        _secondaryChipLabel.Visible = false;
+        //
+        // _pulseTimer
+        //
+        _pulseTimer.Interval = 60;
+        _pulseTimer.Tick += OnPulseTimerTick;
         //
         // ObsOutputStatusCard
         //
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
         Controls.Add(_layoutTableLayoutPanel);
+        DoubleBuffered = true;
         Margin = new Padding(0);
         Name = "ObsOutputStatusCard";
-        Size = new Size(180, 76);
+        Padding = new Padding(2);
+        Size = new Size(180, 160);
         _layoutTableLayoutPanel.ResumeLayout(false);
+        _topLeftLayoutPanel.ResumeLayout(false);
+        _stateRowLayoutPanel.ResumeLayout(false);
+        _topRightLayoutPanel.ResumeLayout(false);
+        _secondaryWrapPanel.ResumeLayout(false);
         ResumeLayout(false);
     }
 
     private TableLayoutPanel _layoutTableLayoutPanel;
-    private Label _titleLabel;
+    private TableLayoutPanel _topLeftLayoutPanel;
+    private Label _kickerLabel;
+    private TableLayoutPanel _stateRowLayoutPanel;
+    private Panel _dotPanel;
     private Label _stateLabel;
+    private TableLayoutPanel _topRightLayoutPanel;
+    private Label _kickerRightLabel;
     private Label _timecodeLabel;
+    private Label _metaLabel;
+    private Button _primaryButton;
+    private Panel _secondaryWrapPanel;
+    private Button _secondaryButton;
+    private Label _secondaryChipLabel;
+    private System.Windows.Forms.Timer _pulseTimer;
 }

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.cs
@@ -1,43 +1,210 @@
-﻿namespace PoproshaykaBot.WinForms.Widgets;
+﻿using Microsoft.Extensions.Logging;
+using PoproshaykaBot.Core.Obs;
+using PoproshaykaBot.WinForms.Infrastructure.Di;
+using System.Drawing.Drawing2D;
+
+namespace PoproshaykaBot.WinForms.Widgets;
 
 public sealed partial class ObsOutputStatusCard : UserControl
 {
+    private static readonly Color ColorIdle = Color.FromArgb(140, 148, 168);
+    private static readonly Color ColorActive = Color.FromArgb(220, 38, 56);
+    private static readonly Color ColorPaused = Color.FromArgb(230, 150, 30);
+    private static readonly Color ColorError = Color.FromArgb(200, 50, 80);
+    private static readonly Color ColorUnknown = Color.Silver;
+
+    private ObsOutputCardKind _kind = ObsOutputCardKind.Stream;
+    private ObsOutputCardState _state = ObsOutputCardState.Unknown;
+    private string? _secondaryChip;
+    private ObsCardChipTone _secondaryChipTone;
+    private double _pulsePhaseSeconds;
+    private bool _initialized;
+    private bool _actionInFlight;
+
     public ObsOutputStatusCard()
     {
         InitializeComponent();
     }
 
-    public void Show(string title, bool? active, bool? paused, string? timecode)
+    [Inject]
+    public ObsIntegrationService ObsIntegration { get; internal init; } = null!;
+
+    [Inject]
+    public ILogger<ObsOutputStatusCard> Logger { get; internal init; } = null!;
+
+    public void Configure(ObsOutputCardKind kind)
     {
-        _titleLabel.Text = title;
-
-        var resolution = ResolveState(active, paused);
-        _stateLabel.Text = resolution.Text;
-        _stateLabel.ForeColor = resolution.Color;
-
-        var formatted = resolution.ShowTimecode ? FormatTimecode(timecode) : null;
-        _timecodeLabel.Text = formatted ?? string.Empty;
-        _timecodeLabel.Visible = !string.IsNullOrEmpty(formatted);
-    }
-
-    private static (string Text, Color Color, bool ShowTimecode) ResolveState(bool? active, bool? paused)
-    {
-        return (active, paused) switch
+        _kind = kind;
+        _kickerLabel.Text = kind switch
         {
-            (true, true) => ("⏸ пауза", Color.Orange, true),
-            (true, _) => ("● идёт", Color.Green, true),
-            (false, _) => ("○ нет", Color.DimGray, false),
-            _ => ("— неизвестно", Color.Gray, false),
+            ObsOutputCardKind.Stream => "ЭФИР",
+            ObsOutputCardKind.Record => "ЗАПИСЬ",
+            _ => string.Empty,
         };
+
+        var streamMode = kind == ObsOutputCardKind.Stream;
+        _secondaryChipLabel.Visible = streamMode;
+        _secondaryButton.Visible = !streamMode;
+
+        ApplyVisualState();
     }
 
-    private static string? FormatTimecode(string? timecode)
+    public void ApplySnapshot(
+        bool? active,
+        bool? paused,
+        string? timecode,
+        string? meta,
+        string? secondaryChip = null,
+        ObsCardChipTone secondaryChipTone = ObsCardChipTone.Neutral)
     {
-        if (string.IsNullOrWhiteSpace(timecode))
+        var nextState = ResolveState(active, paused);
+        _state = nextState;
+        _timecodeLabel.Text = string.IsNullOrWhiteSpace(timecode)
+            ? "—:—:—"
+            : FormatTimecode(timecode);
+
+        _metaLabel.Text = meta ?? string.Empty;
+        _secondaryChip = secondaryChip;
+        _secondaryChipTone = secondaryChipTone;
+        ApplyVisualState();
+    }
+
+    public void ApplyUnavailable(string? errorMessage)
+    {
+        _state = ObsOutputCardState.Error;
+        _timecodeLabel.Text = "—:—:—";
+        _metaLabel.Text = string.IsNullOrWhiteSpace(errorMessage) ? "OBS недоступен" : errorMessage;
+        _secondaryChip = null;
+        _secondaryChipTone = ObsCardChipTone.Neutral;
+        ApplyVisualState();
+    }
+
+    public void ApplyUnknown()
+    {
+        _state = ObsOutputCardState.Unknown;
+        _timecodeLabel.Text = "—:—:—";
+        _metaLabel.Text = string.Empty;
+        _secondaryChip = null;
+        _secondaryChipTone = ObsCardChipTone.Neutral;
+        ApplyVisualState();
+    }
+
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+
+        if (_initialized)
         {
-            return null;
+            return;
         }
 
+        if (this.IsInDesignMode())
+        {
+            ApplyVisualState();
+            return;
+        }
+
+        _initialized = true;
+        ApplyVisualState();
+        Disposed += OnCardDisposed;
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        base.OnPaint(e);
+
+        var bounds = ClientRectangle;
+        bounds.Width -= 1;
+        bounds.Height -= 1;
+
+        var (color, alpha) = ResolveBorderAccent();
+        using var pen = new Pen(Color.FromArgb(alpha, color), 2F);
+        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+        e.Graphics.DrawRectangle(pen, bounds);
+    }
+
+    private void OnPulseTimerTick(object? sender, EventArgs e)
+    {
+        _pulsePhaseSeconds += _pulseTimer.Interval / 1000D;
+        if (_pulsePhaseSeconds > 1000D)
+        {
+            _pulsePhaseSeconds -= 1000D;
+        }
+
+        if (_state == ObsOutputCardState.Paused)
+        {
+            ApplyStateLabelPulse();
+        }
+
+        _dotPanel.Invalidate();
+        Invalidate();
+    }
+
+    private void OnDotPanelPaint(object? sender, PaintEventArgs e)
+    {
+        var color = ResolveStateColor(_state);
+        var (fillColor, diameter) = ResolveDotAccent(color);
+
+        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+        var clientSize = _dotPanel.ClientSize;
+        var x = (clientSize.Width - diameter) / 2F;
+        var y = (clientSize.Height - diameter) / 2F;
+
+        using var brush = new SolidBrush(fillColor);
+        e.Graphics.FillEllipse(brush, x, y, diameter, diameter);
+
+        if (_state is ObsOutputCardState.Active or ObsOutputCardState.Paused)
+        {
+            var haloAlpha = (int)Math.Clamp(fillColor.A * 0.35D, 0D, 90D);
+            using var halo = new SolidBrush(Color.FromArgb(haloAlpha, color));
+            var haloDiameter = diameter + 4F;
+            e.Graphics.FillEllipse(halo,
+                x - 2F,
+                y - 2F,
+                haloDiameter,
+                haloDiameter);
+        }
+    }
+
+    private void OnPrimaryButtonClick(object? sender, EventArgs e)
+    {
+        if (_actionInFlight)
+        {
+            return;
+        }
+
+        var action = ResolvePrimaryAction();
+        if (action is null)
+        {
+            return;
+        }
+
+        _ = InvokeObsActionAsync(action);
+    }
+
+    private void OnSecondaryButtonClick(object? sender, EventArgs e)
+    {
+        if (_actionInFlight || _kind != ObsOutputCardKind.Record)
+        {
+            return;
+        }
+
+        if (_state is not (ObsOutputCardState.Active or ObsOutputCardState.Paused))
+        {
+            return;
+        }
+
+        _ = InvokeObsActionAsync(token => ObsIntegration.ToggleRecordPauseAsync(token));
+    }
+
+    private void OnCardDisposed(object? sender, EventArgs e)
+    {
+        _pulseTimer.Stop();
+    }
+
+    private static string FormatTimecode(string timecode)
+    {
         var dotIndex = timecode.IndexOf('.');
         var withoutMilliseconds = dotIndex >= 0 ? timecode[..dotIndex] : timecode;
 
@@ -51,5 +218,295 @@ public sealed partial class ObsOutputStatusCard : UserControl
         return trimmedHours.Length == 0
             ? $"{parts[1]}:{parts[2]}"
             : $"{trimmedHours}:{parts[1]}:{parts[2]}";
+    }
+
+    private static ObsOutputCardState ResolveState(bool? active, bool? paused)
+    {
+        return (active, paused) switch
+        {
+            (true, true) => ObsOutputCardState.Paused,
+            (true, _) => ObsOutputCardState.Active,
+            (false, _) => ObsOutputCardState.Idle,
+            _ => ObsOutputCardState.Unknown,
+        };
+    }
+
+    private static Color ResolveStateColor(ObsOutputCardState state)
+    {
+        return state switch
+        {
+            ObsOutputCardState.Active => ColorActive,
+            ObsOutputCardState.Paused => ColorPaused,
+            ObsOutputCardState.Idle => ColorIdle,
+            ObsOutputCardState.Error => ColorError,
+            _ => ColorUnknown,
+        };
+    }
+
+    private static Color Lerp(Color from, Color to, double t)
+    {
+        t = Math.Clamp(t, 0D, 1D);
+        return Color.FromArgb((int)Math.Round(from.R + (to.R - from.R) * t),
+            (int)Math.Round(from.G + (to.G - from.G) * t),
+            (int)Math.Round(from.B + (to.B - from.B) * t));
+    }
+
+    private static Color ResolveChipToneColor(ObsCardChipTone tone)
+    {
+        return tone switch
+        {
+            ObsCardChipTone.Ok => Color.Green,
+            ObsCardChipTone.Warn => Color.Orange,
+            ObsCardChipTone.Bad => Color.Red,
+            _ => Color.Gray,
+        };
+    }
+
+    private Func<CancellationToken, Task>? ResolvePrimaryAction()
+    {
+        return (_kind, _state) switch
+        {
+            (ObsOutputCardKind.Stream, ObsOutputCardState.Idle) => token => ObsIntegration.StartStreamAsync(token),
+            (ObsOutputCardKind.Stream, ObsOutputCardState.Active) => token => ObsIntegration.StopStreamAsync(token),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Idle) => token => ObsIntegration.StartRecordAsync(token),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Active) => token => ObsIntegration.StopRecordAsync(token),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Paused) => token => ObsIntegration.StopRecordAsync(token),
+            _ => null,
+        };
+    }
+
+    private async Task InvokeObsActionAsync(Func<CancellationToken, Task> action)
+    {
+        _actionInFlight = true;
+        SetButtonsEnabled(false);
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            await action(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            ShowMetaError("превышено время ожидания");
+        }
+        catch (Exception exception)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            Logger.LogWarning(exception, "Не удалось выполнить OBS-действие для карточки {Kind}", _kind);
+            ShowMetaError("не удалось выполнить");
+        }
+        finally
+        {
+            _actionInFlight = false;
+            if (!IsDisposed)
+            {
+                ApplyVisualState();
+            }
+        }
+    }
+
+    private void ShowMetaError(string message)
+    {
+        _metaLabel.Text = $"⚠ {message}";
+        _metaLabel.ForeColor = ColorActive;
+    }
+
+    private void ApplyVisualState()
+    {
+        var color = ResolveStateColor(_state);
+
+        _stateLabel.Text = ResolveStateText();
+        _stateLabel.ForeColor = color;
+
+        if (!_metaLabel.Text.StartsWith('⚠'))
+        {
+            _metaLabel.ForeColor = Color.Gray;
+        }
+
+        _timecodeLabel.ForeColor = _state switch
+        {
+            ObsOutputCardState.Active => Color.Black,
+            ObsOutputCardState.Paused => ColorPaused,
+            _ => Color.DimGray,
+        };
+
+        ApplyPrimaryButtonState();
+        ApplySecondaryButtonState();
+        ApplyPulseTimerState();
+
+        _dotPanel.Invalidate();
+        Invalidate();
+    }
+
+    private string ResolveStateText()
+    {
+        return (_kind, _state) switch
+        {
+            (_, ObsOutputCardState.Unknown) => "—",
+            (_, ObsOutputCardState.Idle) => "Готов",
+            (ObsOutputCardKind.Stream, ObsOutputCardState.Active) => "В ЭФИРЕ",
+            (ObsOutputCardKind.Record, ObsOutputCardState.Active) => "ЗАПИСЬ",
+            (_, ObsOutputCardState.Paused) => "ПАУЗА",
+            (_, ObsOutputCardState.Error) => "Ошибка",
+            _ => "—",
+        };
+    }
+
+    private void ApplyPrimaryButtonState()
+    {
+        var (text, enabled, intent) = (_kind, _state) switch
+        {
+            (ObsOutputCardKind.Stream, ObsOutputCardState.Idle) => ("▶ Старт", true, Color.Green),
+            (ObsOutputCardKind.Stream, ObsOutputCardState.Active) => ("■ Стоп", true, Color.Red),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Idle) => ("● Старт", true, Color.Green),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Active) => ("■ Стоп", true, Color.Red),
+            (ObsOutputCardKind.Record, ObsOutputCardState.Paused) => ("■ Стоп", true, Color.Red),
+            _ => ("—", false, Color.Gray),
+        };
+
+        _primaryButton.Text = text;
+        _primaryButton.Enabled = enabled && !_actionInFlight;
+        _primaryButton.ForeColor = enabled ? intent : Color.Gray;
+        _primaryButton.FlatAppearance.BorderColor = Color.Silver;
+    }
+
+    private void ApplySecondaryButtonState()
+    {
+        if (_kind != ObsOutputCardKind.Record)
+        {
+            ApplyStreamChip();
+            return;
+        }
+
+        var (text, enabled, intent) = _state switch
+        {
+            ObsOutputCardState.Active => ("⏸ Пауза", true, Color.Orange),
+            ObsOutputCardState.Paused => ("▶ Дальше", true, Color.Green),
+            _ => ("⏸ Пауза", false, Color.Gray),
+        };
+
+        _secondaryButton.Text = text;
+        _secondaryButton.Enabled = enabled && !_actionInFlight;
+        _secondaryButton.ForeColor = enabled ? intent : Color.Gray;
+        _secondaryButton.FlatAppearance.BorderColor = Color.Silver;
+
+        if (_state == ObsOutputCardState.Paused)
+        {
+            _secondaryButton.UseVisualStyleBackColor = false;
+            _secondaryButton.BackColor = Color.LemonChiffon;
+        }
+        else
+        {
+            _secondaryButton.BackColor = SystemColors.Control;
+            _secondaryButton.UseVisualStyleBackColor = true;
+        }
+    }
+
+    private void ApplyStreamChip()
+    {
+        var (text, color) = ResolveStreamChip();
+        _secondaryChipLabel.Text = text;
+        _secondaryChipLabel.ForeColor = color;
+    }
+
+    private (string Text, Color Color) ResolveStreamChip()
+    {
+        if (!string.IsNullOrWhiteSpace(_secondaryChip))
+        {
+            return (_secondaryChip, ResolveChipToneColor(_secondaryChipTone));
+        }
+
+        return _state switch
+        {
+            ObsOutputCardState.Active => ("в эфире", Color.Green),
+            ObsOutputCardState.Idle => ("офлайн", Color.Gray),
+            ObsOutputCardState.Error => ("OBS WS", Color.Red),
+            _ => ("—", Color.Silver),
+        };
+    }
+
+    private void SetButtonsEnabled(bool enabled)
+    {
+        _primaryButton.Enabled = enabled && _primaryButton.Text != "—";
+        _secondaryButton.Enabled = enabled
+                                   && _kind == ObsOutputCardKind.Record
+                                   && _state is ObsOutputCardState.Active or ObsOutputCardState.Paused;
+    }
+
+    private void ApplyPulseTimerState()
+    {
+        var shouldPulse = _state is ObsOutputCardState.Active or ObsOutputCardState.Paused;
+        if (shouldPulse && !_pulseTimer.Enabled)
+        {
+            _pulsePhaseSeconds = 0D;
+            _pulseTimer.Start();
+        }
+        else if (!shouldPulse && _pulseTimer.Enabled)
+        {
+            _pulseTimer.Stop();
+        }
+    }
+
+    private void ApplyStateLabelPulse()
+    {
+        var color = ResolveStateColor(_state);
+        var phase = (Math.Sin(2D * Math.PI * _pulsePhaseSeconds / 1.8D) + 1D) / 2D;
+        var lerp = 0.45D + 0.55D * phase;
+        _stateLabel.ForeColor = Lerp(SystemColors.Control, color, lerp);
+    }
+
+    private (Color BorderColor, int Alpha) ResolveBorderAccent()
+    {
+        var color = ResolveStateColor(_state);
+
+        return _state switch
+        {
+            ObsOutputCardState.Paused => (color, ComputePulseAlpha(60, 220, 1.8D)),
+            ObsOutputCardState.Active => (color, 180),
+            ObsOutputCardState.Error => (color, 200),
+            ObsOutputCardState.Idle => (color, 110),
+            _ => (color, 80),
+        };
+    }
+
+    private (Color FillColor, float Diameter) ResolveDotAccent(Color baseColor)
+    {
+        const float BaseDiameter = 10F;
+
+        switch (_state)
+        {
+            case ObsOutputCardState.Paused:
+                {
+                    var phase = (Math.Sin(2D * Math.PI * _pulsePhaseSeconds / 1.2D) + 1D) / 2D;
+                    var alpha = (int)Math.Round(140D + 115D * phase);
+                    var diameter = BaseDiameter * (float)(0.85D + 0.30D * phase);
+                    return (Color.FromArgb(Math.Clamp(alpha, 0, 255), baseColor), diameter);
+                }
+
+            case ObsOutputCardState.Active:
+                {
+                    var phase = Math.Pow((Math.Sin(2D * Math.PI * _pulsePhaseSeconds / 1.6D) + 1D) / 2D, 4D);
+                    var diameter = BaseDiameter * (float)(1.0D + 0.25D * phase);
+                    return (baseColor, diameter);
+                }
+
+            default:
+                return (baseColor, BaseDiameter);
+        }
+    }
+
+    private int ComputePulseAlpha(int min, int max, double periodSeconds)
+    {
+        var phase = (Math.Sin(2D * Math.PI * _pulsePhaseSeconds / periodSeconds) + 1D) / 2D;
+        return (int)Math.Round(min + (max - min) * phase);
     }
 }

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.cs
@@ -1,0 +1,55 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+public sealed partial class ObsOutputStatusCard : UserControl
+{
+    public ObsOutputStatusCard()
+    {
+        InitializeComponent();
+    }
+
+    public void Show(string title, bool? active, bool? paused, string? timecode)
+    {
+        _titleLabel.Text = title;
+
+        var resolution = ResolveState(active, paused);
+        _stateLabel.Text = resolution.Text;
+        _stateLabel.ForeColor = resolution.Color;
+
+        var formatted = resolution.ShowTimecode ? FormatTimecode(timecode) : null;
+        _timecodeLabel.Text = formatted ?? string.Empty;
+        _timecodeLabel.Visible = !string.IsNullOrEmpty(formatted);
+    }
+
+    private static (string Text, Color Color, bool ShowTimecode) ResolveState(bool? active, bool? paused)
+    {
+        return (active, paused) switch
+        {
+            (true, true) => ("⏸ пауза", Color.Orange, true),
+            (true, _) => ("● идёт", Color.Green, true),
+            (false, _) => ("○ нет", Color.DimGray, false),
+            _ => ("— неизвестно", Color.Gray, false),
+        };
+    }
+
+    private static string? FormatTimecode(string? timecode)
+    {
+        if (string.IsNullOrWhiteSpace(timecode))
+        {
+            return null;
+        }
+
+        var dotIndex = timecode.IndexOf('.');
+        var withoutMilliseconds = dotIndex >= 0 ? timecode[..dotIndex] : timecode;
+
+        var parts = withoutMilliseconds.Split(':');
+        if (parts.Length != 3)
+        {
+            return withoutMilliseconds;
+        }
+
+        var trimmedHours = parts[0].TrimStart('0');
+        return trimmedHours.Length == 0
+            ? $"{parts[1]}:{parts[2]}"
+            : $"{trimmedHours}:{parts[1]}:{parts[2]}";
+    }
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.resx
+++ b/PoproshaykaBot.WinForms/Widgets/ObsOutputStatusCard.resx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+</root>

--- a/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.Designer.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.Designer.cs
@@ -1,0 +1,113 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+sealed partial class ObsSourceMeter
+{
+    private System.ComponentModel.IContainer components = null;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            components?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void InitializeComponent()
+    {
+        _layoutTableLayoutPanel = new TableLayoutPanel();
+        _stateLabel = new Label();
+        _volumeMeterPanel = new Panel();
+        _volumeMeterFillPanel = new Panel();
+        _detailLabel = new Label();
+        _layoutTableLayoutPanel.SuspendLayout();
+        _volumeMeterPanel.SuspendLayout();
+        SuspendLayout();
+        //
+        // _layoutTableLayoutPanel
+        //
+        _layoutTableLayoutPanel.ColumnCount = 1;
+        _layoutTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        _layoutTableLayoutPanel.Controls.Add(_stateLabel, 0, 0);
+        _layoutTableLayoutPanel.Controls.Add(_volumeMeterPanel, 0, 1);
+        _layoutTableLayoutPanel.Controls.Add(_detailLabel, 0, 2);
+        _layoutTableLayoutPanel.Dock = DockStyle.Fill;
+        _layoutTableLayoutPanel.Location = new Point(0, 0);
+        _layoutTableLayoutPanel.Name = "_layoutTableLayoutPanel";
+        _layoutTableLayoutPanel.RowCount = 3;
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 24F));
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 14F));
+        _layoutTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        _layoutTableLayoutPanel.Size = new Size(280, 60);
+        _layoutTableLayoutPanel.TabIndex = 0;
+        //
+        // _stateLabel
+        //
+        _stateLabel.AutoEllipsis = true;
+        _stateLabel.BackColor = Color.Gray;
+        _stateLabel.Dock = DockStyle.Fill;
+        _stateLabel.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+        _stateLabel.ForeColor = Color.White;
+        _stateLabel.Location = new Point(0, 0);
+        _stateLabel.Margin = new Padding(0);
+        _stateLabel.Name = "_stateLabel";
+        _stateLabel.Size = new Size(280, 24);
+        _stateLabel.TabIndex = 0;
+        _stateLabel.Text = "—";
+        _stateLabel.TextAlign = ContentAlignment.MiddleCenter;
+        //
+        // _volumeMeterPanel
+        //
+        _volumeMeterPanel.BackColor = Color.Gainsboro;
+        _volumeMeterPanel.BorderStyle = BorderStyle.FixedSingle;
+        _volumeMeterPanel.Controls.Add(_volumeMeterFillPanel);
+        _volumeMeterPanel.Dock = DockStyle.Fill;
+        _volumeMeterPanel.Location = new Point(0, 26);
+        _volumeMeterPanel.Margin = new Padding(0, 2, 0, 2);
+        _volumeMeterPanel.Name = "_volumeMeterPanel";
+        _volumeMeterPanel.Size = new Size(280, 10);
+        _volumeMeterPanel.TabIndex = 1;
+        _volumeMeterPanel.Resize += OnVolumeMeterPanelResize;
+        //
+        // _volumeMeterFillPanel
+        //
+        _volumeMeterFillPanel.BackColor = Color.SeaGreen;
+        _volumeMeterFillPanel.Dock = DockStyle.Left;
+        _volumeMeterFillPanel.Location = new Point(0, 0);
+        _volumeMeterFillPanel.Name = "_volumeMeterFillPanel";
+        _volumeMeterFillPanel.Size = new Size(0, 8);
+        _volumeMeterFillPanel.TabIndex = 0;
+        //
+        // _detailLabel
+        //
+        _detailLabel.AutoEllipsis = true;
+        _detailLabel.Dock = DockStyle.Fill;
+        _detailLabel.ForeColor = Color.DimGray;
+        _detailLabel.Location = new Point(0, 38);
+        _detailLabel.Margin = new Padding(0);
+        _detailLabel.Name = "_detailLabel";
+        _detailLabel.Size = new Size(280, 22);
+        _detailLabel.TabIndex = 2;
+        _detailLabel.Text = "—";
+        _detailLabel.TextAlign = ContentAlignment.MiddleLeft;
+        //
+        // ObsSourceMeter
+        //
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        Controls.Add(_layoutTableLayoutPanel);
+        Margin = new Padding(0, 0, 0, 4);
+        Name = "ObsSourceMeter";
+        Size = new Size(280, 60);
+        _layoutTableLayoutPanel.ResumeLayout(false);
+        _volumeMeterPanel.ResumeLayout(false);
+        ResumeLayout(false);
+    }
+
+    private TableLayoutPanel _layoutTableLayoutPanel;
+    private Label _stateLabel;
+    private Panel _volumeMeterPanel;
+    private Panel _volumeMeterFillPanel;
+    private Label _detailLabel;
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.cs
+++ b/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.cs
@@ -1,0 +1,83 @@
+﻿namespace PoproshaykaBot.WinForms.Widgets;
+
+public sealed partial class ObsSourceMeter : UserControl
+{
+    public ObsSourceMeter()
+    {
+        InitializeComponent();
+    }
+
+    public string SourceName { get; set; } = string.Empty;
+
+    public bool Muted { get; set; }
+
+    public bool Found { get; set; }
+
+    public double CurrentLevel { get; private set; }
+
+    public void ShowActive(string displayName, double? volumeDecibels)
+    {
+        SetState(displayName, Color.SeaGreen, Color.White);
+        _detailLabel.Text = volumeDecibels.HasValue
+            ? $"включён · {volumeDecibels.Value:0.#} дБ"
+            : "включён";
+
+        _detailLabel.ForeColor = Color.Green;
+    }
+
+    public void ShowMuted(string displayName, double? volumeDecibels)
+    {
+        SetState(displayName, Color.Firebrick, Color.White);
+        _detailLabel.Text = volumeDecibels.HasValue
+            ? $"выключен · {volumeDecibels.Value:0.#} дБ"
+            : "выключен";
+
+        _detailLabel.ForeColor = Color.Red;
+        ApplyVolumeMeterLevel(0);
+    }
+
+    public void ShowMissing(string displayName)
+    {
+        SetState(displayName, Color.DarkOrange, Color.Black);
+        _detailLabel.Text = "источник не найден";
+        _detailLabel.ForeColor = Color.Orange;
+        ApplyVolumeMeterLevel(0);
+    }
+
+    public void ApplyVolumeMeterLevel(double level)
+    {
+        var normalized = Math.Clamp(level, 0D, 1D);
+        CurrentLevel = normalized;
+        var width = (int)Math.Round(_volumeMeterPanel.ClientSize.Width * normalized);
+
+        _volumeMeterFillPanel.Width = Math.Max(0, width);
+        _volumeMeterFillPanel.BackColor = ResolveVolumeMeterColor(normalized);
+    }
+
+    private void OnVolumeMeterPanelResize(object? sender, EventArgs e)
+    {
+        ApplyVolumeMeterLevel(CurrentLevel);
+    }
+
+    private static Color ResolveVolumeMeterColor(double normalized)
+    {
+        if (normalized >= 0.9D)
+        {
+            return Color.Firebrick;
+        }
+
+        if (normalized >= 0.68D)
+        {
+            return Color.DarkOrange;
+        }
+
+        return Color.SeaGreen;
+    }
+
+    private void SetState(string displayName, Color backColor, Color foreColor)
+    {
+        _stateLabel.Text = string.IsNullOrWhiteSpace(displayName) ? "—" : displayName.Trim();
+        _stateLabel.BackColor = backColor;
+        _stateLabel.ForeColor = foreColor;
+    }
+}

--- a/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.resx
+++ b/PoproshaykaBot.WinForms/Widgets/ObsSourceMeter.resx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+    </resheader>
+</root>

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -81,6 +81,7 @@ function Invoke-DotnetPublish {
         '--output', $variantDir,
         '-p:PublishSingleFile=true',
         '-p:PublishReadyToRun=true',
+        '-p:UpdatableBuild=true',
         "-p:Version=$Version"
     )
 
@@ -129,10 +130,38 @@ function Invoke-DotnetPublish {
     Write-Output "  -> $zipName"
 }
 
+function Write-ReleaseMetadata {
+    param(
+        [string]$Arch
+    )
+
+    $exes = @(Get-ChildItem -LiteralPath $OutputDir -Filter "PoproshaykaBot-v$Version-$Arch*.exe")
+    if ($exes.Count -eq 0) {
+        return
+    }
+
+    $sumsPath = Join-Path $OutputDir "SHA256SUMS-$Arch.txt"
+    $lines = foreach ($exe in $exes) {
+        $hash = (Get-FileHash -LiteralPath $exe.FullName -Algorithm SHA256).Hash.ToLower()
+        "$hash  $($exe.Name)"
+    }
+    Set-Content -LiteralPath $sumsPath -Value $lines -Encoding ascii
+
+    $csprojPath = Join-Path $projectDir 'PoproshaykaBot.WinForms.csproj'
+    $tfm = (Select-String -LiteralPath $csprojPath -Pattern '<TargetFramework>(.*?)</TargetFramework>').Matches[0].Groups[1].Value
+    $runtimePath = Join-Path $OutputDir "RUNTIME-$Arch.txt"
+    Set-Content -LiteralPath $runtimePath -Value $tfm -Encoding ascii -NoNewline
+
+    Write-Output "  -> SHA256SUMS-$Arch.txt"
+    Write-Output "  -> RUNTIME-$Arch.txt"
+}
+
 foreach ($a in $Arch) {
     foreach ($v in $Variant) {
         Invoke-DotnetPublish -Arch $a -Variant $v
     }
+
+    Write-ReleaseMetadata -Arch $a
 }
 
 if (Test-Path -LiteralPath $publishRoot) {


### PR DESCRIPTION
<img width="2546" height="1318" alt="image" src="https://github.com/user-attachments/assets/cebaa400-cf2d-4599-82ad-4532e7518974" />

Автообновление
- Автообновление приложения через GitHub-релизы
- Отсев релизов без контрольных сумм (SHA256SUMS)
- Повторные попытки инициализации WebView2 при обновлении

OBS-виджет
- Несколько отслеживаемых аудио-источников
- Статус-блоки и редизайн карточек эфира и записи

Чат-оверлей
- Сочные анимации чата и демо-страница в оверлее
- Веб-настройка чат-оверлея через демо-страницу, сервер как источник правды
- Жёсткое обновление чат-источников OBS
- Чат-команды по истории стримов
- Игнорирование собственных сообщений бота в чат-пайплайне

Прочее
- Защита от повторного запуска приложения
- Вкладка OBS-подключения разбита на подвкладки
- Диагностика пустого прощания в FarewellMessageHandler
- Исправлены SonarQube Security Hotspots
